### PR TITLE
Added refetch_delay to server config

### DIFF
--- a/src/cactus_client/cli/server.py
+++ b/src/cactus_client/cli/server.py
@@ -31,6 +31,7 @@ class ServerConfigKey(StrEnum):
     SERCA = auto()
     NOTIFICATION = auto()
     PEN = auto()
+    REFETCH_DELAY = auto()
 
 
 def add_sub_commands(subparsers: argparse._SubParsersAction) -> None:
@@ -81,6 +82,8 @@ def update_server_key(
                 return replace(server, notification_uri=new_value)
             case ServerConfigKey.PEN:
                 return replace(server, pen=int(new_value))
+            case ServerConfigKey.REFETCH_DELAY:
+                return replace(server, refetch_delay_ms=int(new_value))
             case _:
                 console.print(f"[b]{config_key}[/b] can't be updated", style="red")
                 sys.exit(1)
@@ -102,6 +105,7 @@ def print_server(console: Console, config: GlobalConfig) -> None:
     serca_pem_file = config.server.serca_pem_file if config.server else None
     notification = config.server.notification_uri if config.server else None
     pen = config.server.pen if config.server else 0
+    refetch_delay_ms = config.server.refetch_delay_ms if config.server else 0
 
     table.add_row(
         "dcap",
@@ -133,6 +137,12 @@ def print_server(console: Console, config: GlobalConfig) -> None:
         "pen",
         str(pen) if pen else "[b red]0[/b red]",
         "[b]Private Enterprise Number[/b] for the server. This will used when validating server generated mRID's.",
+    )
+    table.add_row(
+        "refetch_delay",
+        f"{refetch_delay_ms}ms" if refetch_delay_ms else "None",
+        "Delay (in milliseconds) that the client will apply between submitting a 'write' request and then fetching"
+        + " the updated value.",
     )
     console.print(table)
 

--- a/src/cactus_client/model/config.py
+++ b/src/cactus_client/model/config.py
@@ -32,6 +32,9 @@ class ServerConfig:
     serca_pem_file: str | None = None  # The file path to the SERCA PEM that the server will be using as a trust anchor
     notification_uri: str | None = None  # The base URI of the cactus-client-notifications that will be used for pub/sub
     pen: int = 0  # The Private Enterprise Number that server will be expected to utilise
+    refetch_delay_ms: int = (
+        0  # When the client pushes a write request, wait this long (milliseconds) before fetching it to compare
+    )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Support for an artificial delay AFTER submitting a "write" request (eg PUT DERSettings) that will come into effect before the test re-fetches the newly updated resource.

Used for server implementations that do writing of updates async.