### PR TITLE
Fix test failures caused by assertical v0.3.3 dict generation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,11 @@ import pytest
 from aiohttp import ClientSession
 from assertical.fake.generator import generate_class_instance, register_value_generator
 from assertical.fixtures.generator import generator_registry_snapshot
+from cactus_test_definitions.server.actions import Action
 from cactus_test_definitions.server.test_procedures import (
     Preconditions,
     RequiredClient,
+    Step,
     TestProcedure,
     TestProcedureId,
 )
@@ -68,6 +70,7 @@ def dummy_test_procedure(dummy_client_alias_1, assertical_extensions) -> TestPro
             optional_is_none=True,
             required_clients=[generate_class_instance(RequiredClient, id=dummy_client_alias_1)],
         ),
+        steps=[],  # Action.parameters is dict[str, Any] which assertical cannot generate
     )
 
 
@@ -110,6 +113,11 @@ def testing_contexts_factory(dummy_test_procedure) -> Callable[[ClientSession], 
             generate_relationships=True,
             client_alias=client_alias,
             client_resources_alias=client_alias,
+            source=generate_class_instance(
+                Step,
+                optional_is_none=True,
+                action=Action(type="dummy"),  # Action.parameters is dict[str, Any] which assertical cannot generate
+            ),
         )
 
         return (execution_context, step_execution)

--- a/tests/unit/cactus_client/results/test_common.py
+++ b/tests/unit/cactus_client/results/test_common.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 from assertical.fake.generator import generate_class_instance, generate_value
+from cactus_test_definitions.server.actions import Action
 from cactus_test_definitions.server.test_procedures import (
     Step,
     TestProcedure,
@@ -32,6 +33,11 @@ from cactus_client.model.progress import (
 )
 from cactus_client.model.resource import RESOURCE_SEP2_TYPES, CSIPAusResourceTree
 from cactus_client.results.common import ResultsEvaluation
+
+
+def generate_step(seed: int) -> Step:
+    """Generate a Step with an explicit Action to avoid assertical trying to generate dict[str, Any]."""
+    return generate_class_instance(Step, seed=seed, action=Action(type="dummy"))
 
 
 def generate_server_response(seed: int, xsd_errors: list[str] | None) -> ServerResponse:
@@ -87,8 +93,8 @@ def generate_empty_context(steps: list[Step]) -> ExecutionContext:
 
 @pytest.mark.asyncio
 async def test_ResultsEvaluation_passed(assertical_extensions):
-    step_1 = generate_class_instance(Step, seed=1, generate_relationships=True)
-    step_2 = generate_class_instance(Step, seed=2, generate_relationships=True)
+    step_1 = generate_step(1)
+    step_2 = generate_step(2)
 
     context = generate_empty_context([step_1, step_2])
 
@@ -118,8 +124,8 @@ async def test_ResultsEvaluation_passed(assertical_extensions):
 
 @pytest.mark.asyncio
 async def test_ResultsEvaluation_failing_missing_result(assertical_extensions):
-    step_1 = generate_class_instance(Step, seed=1, generate_relationships=True)
-    step_2 = generate_class_instance(Step, seed=2, generate_relationships=True)
+    step_1 = generate_step(1)
+    step_2 = generate_step(2)
 
     context = generate_empty_context([step_1, step_2])
 
@@ -149,8 +155,8 @@ async def test_ResultsEvaluation_failing_missing_result(assertical_extensions):
 
 @pytest.mark.asyncio
 async def test_ResultsEvaluation_failing_xsd_errors(assertical_extensions):
-    step_1 = generate_class_instance(Step, seed=1, generate_relationships=True)
-    step_2 = generate_class_instance(Step, seed=2, generate_relationships=True)
+    step_1 = generate_step(1)
+    step_2 = generate_step(2)
 
     context = generate_empty_context([step_1, step_2])
 
@@ -181,8 +187,8 @@ async def test_ResultsEvaluation_failing_xsd_errors(assertical_extensions):
 
 @pytest.mark.asyncio
 async def test_ResultsEvaluation_failing_xsd_errors_notifications(assertical_extensions):
-    step_1 = generate_class_instance(Step, seed=1, generate_relationships=True)
-    step_2 = generate_class_instance(Step, seed=2, generate_relationships=True)
+    step_1 = generate_step(1)
+    step_2 = generate_step(2)
 
     context = generate_empty_context([step_1, step_2])
 
@@ -213,8 +219,8 @@ async def test_ResultsEvaluation_failing_xsd_errors_notifications(assertical_ext
 
 @pytest.mark.asyncio
 async def test_ResultsEvaluation_failing_warning(assertical_extensions):
-    step_1 = generate_class_instance(Step, seed=1, generate_relationships=True)
-    step_2 = generate_class_instance(Step, seed=2, generate_relationships=True)
+    step_1 = generate_step(1)
+    step_2 = generate_step(2)
 
     context = generate_empty_context([step_1, step_2])
 
@@ -245,8 +251,8 @@ async def test_ResultsEvaluation_failing_warning(assertical_extensions):
 
 @pytest.mark.asyncio
 async def test_ResultsEvaluation_failing_failing_step(assertical_extensions):
-    step_1 = generate_class_instance(Step, seed=1, generate_relationships=True)
-    step_2 = generate_class_instance(Step, seed=2, generate_relationships=True)
+    step_1 = generate_step(1)
+    step_2 = generate_step(2)
 
     context = generate_empty_context([step_1, step_2])
 


### PR DESCRIPTION
NOTE: Coverage is failing due to broken tests in MAIN not this PR

Upgrading from assertical v0.3.1 → v0.3.3 broke a bunch of tests. The failures look like: _Exception: Type None does not inherit from one of dict_keys([...])_

This comes from Action.parameters, which are typed as dict[str, Any]. In v0.3.1, the assertical_extensions fixture registered register_value_generator(dict, lambda _: {}), intercepted any dict field and returned {} before assertical inspected the type arguments. In v0.3.3, dict fields are now detected as collections before the primitive value generator registry is checked, so the register_value_generator(dict, ...) workaround is silently bypassed. Assertical then tries to generate a value of type Any and crashes.

Easy to fix though:
Wherever Step or Action is auto-generated with generate_relationships=True, action just needs to be defined (or steps set to an empty list so they dont generate Actions downstream).
