### PR TITLE
feat: s-all-01 with admin plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ This is a set of tools for evaluating CSIP-Aus server test procedures defined at
 <img width="1841" height="1003" alt="image" src="https://github.com/user-attachments/assets/0ee5b02e-cb21-476a-a6f2-975f23ecc5ae" />
 
 
-## Development
-
-`pip install -e .[dev,test]`
-
 ## Quickstart
 
 ### Installing
@@ -118,4 +114,14 @@ The command `cactus tests` will print out all available test cases...
 ### Running your first test
 
 The following command will run the `S-ALL-01` test with the client you created earlier `cactus run S-ALL-01 myclient1`
+
+## Development
+
+`pip install -e .[dev,test]`
+
+### Admin plugins
+
+Plugins can be developed using [apluggy](https://github.com/nextline-dev/apluggy), a simple async wrapper around pytest's [pluggy](https://github.com/pytest-dev/pluggy)
+
+See [hookspecs.py](src/cactus-client/admin/hookspecs.py) for the current list of exposed hookspecs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,24 @@ profile = "black"
 exclude_dirs = ["tests"]
 
 [tool.mypy]
-exclude = ["tests", "build"]
+python_version = "3.12"
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_calls = true
-disallow_untyped_decorators = true
 disallow_untyped_defs = true
+disallow_untyped_decorators = true
 namespace_packages = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+exclude = "^(tests|build)/"
+
+[[tool.mypy.overrides]]
+module = ["apluggy.*", "apluggy"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["cactus_client.admin", "cactus_client.admin.*"]
+disallow_untyped_decorators = false
 
 
 [build-system]
@@ -44,6 +53,7 @@ dependencies = [
     "reportlab>=4.4.1,<5",
     "cryptography",
     "tzdata; platform_system == 'Windows'",
+    "apluggy",
 ]
 
 [project.optional-dependencies]
@@ -66,7 +76,6 @@ test = ["assertical", "pytest", "pytest-aiohttp", "freezegun", "cryptography"]
 [tool.setuptools.dynamic]
 version = { attr = "cactus_client.__version__" }
 readme = { file = ["README.md"], content-type = "text/markdown" }
-
 
 [project.scripts]
 cactus = "cactus_client.cli.main:cli_entrypoint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ ignore_missing_imports = true
 module = ["cactus_client.admin", "cactus_client.admin.*"]
 disallow_untyped_decorators = false
 
-
 [build-system]
 requires = ["setuptools >= 40.9.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ name = "cactus_client"
 dynamic = ["version", "readme"]
 description = "Tools for evaluating a CSIP Aus server implementation via a virtual client"
 dependencies = [
-    "cactus-test-definitions==1.9.7",
+    "cactus-test-definitions @ git+https://github.com/synergy-au/cactus-test-definitions.git@joe/exploring-admin-api",
     "cactus-schema>=0.0.11",
     "envoy-schema>=0.31.1",
     "rich>=14.1.0,<15",

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,3 @@ packages = find_namespace:
 [options.packages.find]
 where = ./src
 exclude = tests*
-
-[mypy-apluggy]
-ignore_missing_imports = True
-
-[mypy-apluggy.*]
-ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,9 @@ packages = find_namespace:
 [options.packages.find]
 where = ./src
 exclude = tests*
+
+[mypy-apluggy]
+ignore_missing_imports = True
+
+[mypy-apluggy.*]
+ignore_missing_imports = True

--- a/src/cactus_client/action/__init__.py
+++ b/src/cactus_client/action/__init__.py
@@ -55,12 +55,12 @@ async def execute_action(step: StepExecution, context: ExecutionContext) -> Acti
         # Reserved action
         case "admin-setup":
             pm = admin.get_plugin_manager()
-            results = await pm.ahook.admin_setup(context=context)
+            results = await pm.ahook.admin_setup(context=context, step=step)
             return results[0]
         # Reserved action
         case "admin-teardown":
             pm = admin.get_plugin_manager()
-            results = await pm.ahook.admin_teardown(context=context)
+            results = await pm.ahook.admin_teardown(context=context, step=step)
             return results[0]
         case "no-op":
             return await action_noop()

--- a/src/cactus_client/action/__init__.py
+++ b/src/cactus_client/action/__init__.py
@@ -30,6 +30,7 @@ from cactus_client.error import CactusClientException
 from cactus_client.model.context import ExecutionContext
 from cactus_client.model.execution import ActionResult, StepExecution
 from cactus_client.model.parameter import resolve_variable_expressions_from_parameters
+from cactus_client import admin
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +90,8 @@ async def execute_action(step: StepExecution, context: ExecutionContext) -> Acti
             return await action_wait(resolved_params)
         case "simulate-client":
             return await action_simulate_client(resolved_params, step, context)
-
+        case "admin-device-register":
+            return await admin.manager.pm.ahook.admin_device_register(resolved_params, step, context)
         case _:
             logger.error(f"Unrecognised action type {action_info.type} in step {step.source.id}")
             raise CactusClientException(

--- a/src/cactus_client/action/__init__.py
+++ b/src/cactus_client/action/__init__.py
@@ -54,11 +54,13 @@ async def execute_action(step: StepExecution, context: ExecutionContext) -> Acti
     match (action_info.type):
         # Reserved action
         case "admin-setup":
-            results = await admin.manager.pm.ahook.admin_setup(context=context)
+            pm = admin.get_plugin_manager()
+            results = await pm.ahook.admin_setup(context=context)
             return results[0]
         # Reserved action
         case "admin-teardown":
-            results = await admin.manager.pm.ahook.admin_teardown(context=context)
+            pm = admin.get_plugin_manager()
+            results = await pm.ahook.admin_teardown(context=context)
             return results[0]
         case "no-op":
             return await action_noop()
@@ -99,7 +101,8 @@ async def execute_action(step: StepExecution, context: ExecutionContext) -> Acti
         case "simulate-client":
             return await action_simulate_client(resolved_params, step, context)
         case "admin-device-register":
-            results = await admin.manager.pm.ahook.admin_device_register(
+            pm = admin.get_plugin_manager()
+            results = await pm.ahook.admin_device_register(
                 resolved_params=resolved_params, step=step, context=context
             )
             return results[0]

--- a/src/cactus_client/action/__init__.py
+++ b/src/cactus_client/action/__init__.py
@@ -91,7 +91,10 @@ async def execute_action(step: StepExecution, context: ExecutionContext) -> Acti
         case "simulate-client":
             return await action_simulate_client(resolved_params, step, context)
         case "admin-device-register":
-            return await admin.manager.pm.ahook.admin_device_register(resolved_params, step, context)
+            results = await admin.manager.pm.ahook.admin_device_register(
+                resolved_params=resolved_params, step=step, context=context
+            )
+            return results[0]
         case _:
             logger.error(f"Unrecognised action type {action_info.type} in step {step.source.id}")
             raise CactusClientException(

--- a/src/cactus_client/action/__init__.py
+++ b/src/cactus_client/action/__init__.py
@@ -52,6 +52,14 @@ async def execute_action(step: StepExecution, context: ExecutionContext) -> Acti
         )
 
     match (action_info.type):
+        # Reserved action
+        case "admin-setup":
+            results = await admin.manager.pm.ahook.admin_setup(context=context)
+            return results[0]
+        # Reserved action
+        case "admin-teardown":
+            results = await admin.manager.pm.ahook.admin_teardown(context=context)
+            return results[0]
         case "no-op":
             return await action_noop()
         case "discovery":

--- a/src/cactus_client/admin/__init__.py
+++ b/src/cactus_client/admin/__init__.py
@@ -1,0 +1,3 @@
+from .hooks import hookspec, hookimpl, project_name  # noqa
+from . import manager  # noqa
+from . import default_impl  # noqa

--- a/src/cactus_client/admin/__init__.py
+++ b/src/cactus_client/admin/__init__.py
@@ -1,3 +1,3 @@
 from .hooks import hookspec, hookimpl, project_name  # noqa
-from . import manager  # noqa
+from .manager import get_plugin_manager  # noqa
 from . import default_impl  # noqa

--- a/src/cactus_client/admin/default_impl.py
+++ b/src/cactus_client/admin/default_impl.py
@@ -1,0 +1,26 @@
+from . import hookimpl
+
+from cactus_client.model.context import ExecutionContext
+from cactus_client.model.execution import StepExecution, ActionResult
+
+from typing import Any
+
+
+@hookimpl(trylast=True)
+async def admin_setup(step: StepExecution, context: ExecutionContext) -> ActionResult:
+    """General setup function to be run at the beginning of all test runs."""
+    return ActionResult(completed=True, repeat=False, not_before=None)
+
+
+@hookimpl(trylast=True)
+async def admin_teardown(step: StepExecution, context: ExecutionContext) -> ActionResult:
+    """General teardown function to be run at the end of all test runs."""
+    return ActionResult(completed=True, repeat=False, not_before=None)
+
+
+@hookimpl(trylast=True)
+async def admin_device_register(
+    resolved_params: dict[str, Any], step: StepExecution, context: ExecutionContext
+) -> ActionResult:
+    """Out-of-band register a device."""
+    return ActionResult(completed=True, repeat=False, not_before=None)

--- a/src/cactus_client/admin/default_impl.py
+++ b/src/cactus_client/admin/default_impl.py
@@ -6,21 +6,20 @@ from cactus_client.model.execution import StepExecution, ActionResult
 from typing import Any
 
 
-@hookimpl(trylast=True)
-async def admin_setup(step: StepExecution, context: ExecutionContext) -> ActionResult:
-    """General setup function to be run at the beginning of all test runs."""
-    return ActionResult(completed=True, repeat=False, not_before=None)
+class DefaultPlugin:
+    @hookimpl(trylast=True)
+    async def admin_setup(self, step: StepExecution, context: ExecutionContext) -> ActionResult:
+        """General setup function to be run at the beginning of all test runs."""
+        return ActionResult(completed=True, repeat=False, not_before=None)
 
+    @hookimpl(trylast=True)
+    async def admin_teardown(self, step: StepExecution, context: ExecutionContext) -> ActionResult:
+        """General teardown function to be run at the end of all test runs."""
+        return ActionResult(completed=True, repeat=False, not_before=None)
 
-@hookimpl(trylast=True)
-async def admin_teardown(step: StepExecution, context: ExecutionContext) -> ActionResult:
-    """General teardown function to be run at the end of all test runs."""
-    return ActionResult(completed=True, repeat=False, not_before=None)
-
-
-@hookimpl(trylast=True)
-async def admin_device_register(
-    resolved_params: dict[str, Any], step: StepExecution, context: ExecutionContext
-) -> ActionResult:
-    """Out-of-band register a device."""
-    return ActionResult(completed=True, repeat=False, not_before=None)
+    @hookimpl(trylast=True)
+    async def admin_device_register(
+        self, resolved_params: dict[str, Any], step: StepExecution, context: ExecutionContext
+    ) -> ActionResult:
+        """Out-of-band register a device."""
+        return ActionResult(completed=True, repeat=False, not_before=None)

--- a/src/cactus_client/admin/default_impl.py
+++ b/src/cactus_client/admin/default_impl.py
@@ -8,12 +8,12 @@ from typing import Any
 
 class DefaultPlugin:
     @hookimpl(trylast=True)
-    async def admin_setup(self, context: ExecutionContext) -> ActionResult:
+    async def admin_setup(self, step: StepExecution, context: ExecutionContext) -> ActionResult:
         """General setup function to be run at the beginning of all test runs."""
         return ActionResult.done()
 
     @hookimpl(trylast=True)
-    async def admin_teardown(self, context: ExecutionContext) -> ActionResult:
+    async def admin_teardown(self, step: StepExecution, context: ExecutionContext) -> ActionResult:
         """General teardown function to be run at the end of all test runs."""
         return ActionResult.done()
 

--- a/src/cactus_client/admin/default_impl.py
+++ b/src/cactus_client/admin/default_impl.py
@@ -8,18 +8,18 @@ from typing import Any
 
 class DefaultPlugin:
     @hookimpl(trylast=True)
-    async def admin_setup(self, step: StepExecution, context: ExecutionContext) -> ActionResult:
+    async def admin_setup(self, context: ExecutionContext) -> ActionResult:
         """General setup function to be run at the beginning of all test runs."""
-        return ActionResult(completed=True, repeat=False, not_before=None)
+        return ActionResult.done()
 
     @hookimpl(trylast=True)
-    async def admin_teardown(self, step: StepExecution, context: ExecutionContext) -> ActionResult:
+    async def admin_teardown(self, context: ExecutionContext) -> ActionResult:
         """General teardown function to be run at the end of all test runs."""
-        return ActionResult(completed=True, repeat=False, not_before=None)
+        return ActionResult.done()
 
     @hookimpl(trylast=True)
     async def admin_device_register(
         self, resolved_params: dict[str, Any], step: StepExecution, context: ExecutionContext
     ) -> ActionResult:
         """Out-of-band register a device."""
-        return ActionResult(completed=True, repeat=False, not_before=None)
+        return ActionResult.done()

--- a/src/cactus_client/admin/hooks.py
+++ b/src/cactus_client/admin/hooks.py
@@ -1,0 +1,8 @@
+import apluggy
+
+project_name = "cactus-client-admin"
+
+hookspec = apluggy.HookspecMarker(project_name)
+hookimpl = apluggy.HookimplMarker(project_name)
+
+API_VERSION = "0.1"

--- a/src/cactus_client/admin/hooks.py
+++ b/src/cactus_client/admin/hooks.py
@@ -1,8 +1,8 @@
 import apluggy
 
-project_name = "cactus-client-admin"
+project_name = "cactus_client.admin"
 
 hookspec = apluggy.HookspecMarker(project_name)
 hookimpl = apluggy.HookimplMarker(project_name)
 
-API_VERSION = "0.1"
+API_VERSION = "0.1.0"

--- a/src/cactus_client/admin/hookspecs.py
+++ b/src/cactus_client/admin/hookspecs.py
@@ -7,15 +7,15 @@ from typing import Any
 
 
 class Spec:
-    @hookspec(firstresult=True)
-    async def admin_setup(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
+    @hookspec
+    def admin_setup(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
         """General setup function to be run at the beginning of all test runs."""
 
-    @hookspec(firstresult=True)
-    async def admin_teardown(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
+    @hookspec
+    def admin_teardown(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
         """General teardown function to be run at the end of all test runs."""
 
-    @hookspec(firstresult=True)
+    @hookspec
     async def admin_device_register(  # type: ignore[empty-body]
         self, resolved_params: dict[str, Any], step: StepExecution, context: ExecutionContext
     ) -> ActionResult:

--- a/src/cactus_client/admin/hookspecs.py
+++ b/src/cactus_client/admin/hookspecs.py
@@ -8,11 +8,11 @@ from typing import Any
 
 class Spec:
     @hookspec
-    def admin_setup(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
+    def admin_setup(self, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
         """General setup function to be run at the beginning of all test runs."""
 
     @hookspec
-    def admin_teardown(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
+    def admin_teardown(self, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
         """General teardown function to be run at the end of all test runs."""
 
     @hookspec

--- a/src/cactus_client/admin/hookspecs.py
+++ b/src/cactus_client/admin/hookspecs.py
@@ -8,11 +8,11 @@ from typing import Any
 
 class Spec:
     @hookspec
-    def admin_setup(self, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
+    def admin_setup(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
         """General setup function to be run at the beginning of all test runs."""
 
     @hookspec
-    def admin_teardown(self, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
+    def admin_teardown(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
         """General teardown function to be run at the end of all test runs."""
 
     @hookspec

--- a/src/cactus_client/admin/hookspecs.py
+++ b/src/cactus_client/admin/hookspecs.py
@@ -1,0 +1,22 @@
+from . import hookspec
+
+from cactus_client.model.context import ExecutionContext
+from cactus_client.model.execution import StepExecution, ActionResult
+
+from typing import Any
+
+
+class Spec:
+    @hookspec(firstresult=True)
+    async def admin_setup(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
+        """General setup function to be run at the beginning of all test runs."""
+
+    @hookspec(firstresult=True)
+    async def admin_teardown(self, step: StepExecution, context: ExecutionContext) -> ActionResult:  # type: ignore[empty-body]
+        """General teardown function to be run at the end of all test runs."""
+
+    @hookspec(firstresult=True)
+    async def admin_device_register(  # type: ignore[empty-body]
+        self, resolved_params: dict[str, Any], step: StepExecution, context: ExecutionContext
+    ) -> ActionResult:
+        """Out-of-band register a device."""

--- a/src/cactus_client/admin/manager.py
+++ b/src/cactus_client/admin/manager.py
@@ -1,0 +1,12 @@
+import apluggy
+from . import project_name
+from . import hookspecs
+from . import default_impl
+
+pm = apluggy.PluginManager(project_name)
+pm.add_hookspecs(hookspecs.Spec)
+pm.register(default_impl, name="builtin-default")  # The standard manual implementation
+
+
+def get_plugin_manager() -> apluggy.PluginManager:
+    return pm

--- a/src/cactus_client/admin/manager.py
+++ b/src/cactus_client/admin/manager.py
@@ -5,7 +5,7 @@ from . import default_impl
 
 pm = apluggy.PluginManager(project_name)
 pm.add_hookspecs(hookspecs.Spec)
-pm.register(default_impl, name="builtin-default")  # The standard manual implementation
+pm.register(default_impl.DefaultPlugin())
 
 
 def get_plugin_manager() -> apluggy.PluginManager:

--- a/src/cactus_client/admin/manager.py
+++ b/src/cactus_client/admin/manager.py
@@ -3,10 +3,15 @@ from . import project_name
 from . import hookspecs
 from . import default_impl
 
-pm = apluggy.PluginManager(project_name)
-pm.add_hookspecs(hookspecs.Spec)
-pm.register(default_impl.DefaultPlugin())
-
 
 def get_plugin_manager() -> apluggy.PluginManager:
+    """Produces the plugin manager for the project."""
+    pm = apluggy.PluginManager(project_name)
+    pm.add_hookspecs(hookspecs.Spec)
+    pm.register(default_impl.DefaultPlugin())
+
+    # Discover and load plugins via entrypoints
+    pm.load_setuptools_entrypoints(project_name)
+    pm.check_pending()
+
     return pm

--- a/src/cactus_client/execution/execute.py
+++ b/src/cactus_client/execution/execute.py
@@ -35,6 +35,7 @@ async def setup_and_teardown(context: ExecutionContext) -> AsyncIterator[ActionR
     setup_step = StepExecution.admin_setup()
     logger.debug("====== Running admin setup ======")
 
+    setup_step.client_alias = next(iter(context.clients_by_alias))
     try:
         action_result = await execute_action(setup_step, context)
         await context.progress.set_step_result(setup_step, action_result, dummy_check_result)

--- a/src/cactus_client/execution/execute.py
+++ b/src/cactus_client/execution/execute.py
@@ -74,10 +74,11 @@ async def execute_for_context(context: ExecutionContext) -> ExecutionResult:
         Overall result of the test execution
     """
     # Context manager with the setup and teardown functionality
-    async with setup_and_teardown(context) as setup_result:
-        if not setup_result.completed:
-            return ExecutionResult(completed=False)
+    # async with setup_and_teardown(context) as setup_result:
+    #    if not setup_result.completed:
+    #        return ExecutionResult(completed=False)
 
+    if True:  # TODO remove temporary bridge
         while (upcoming_step := context.steps.peek_next_no_wait(now := utc_now())) is not None:
 
             # Sometimes the next step will have a "not before" time - in which case we delay until that time has passed

--- a/src/cactus_client/execution/execute.py
+++ b/src/cactus_client/execution/execute.py
@@ -45,6 +45,7 @@ async def setup_and_teardown(context: ExecutionContext) -> AsyncIterator[ActionR
     except Exception as exc:
         logger.error("Admin setup exception", exc_info=exc)
         await context.progress.add_step_execution_exception(setup_step, exc)
+        raise
 
     finally:
         # Teardown

--- a/src/cactus_client/execution/execute.py
+++ b/src/cactus_client/execution/execute.py
@@ -1,13 +1,17 @@
 import asyncio
 import logging
 from dataclasses import replace
+from contextlib import asynccontextmanager
 
-from cactus_client.action import execute_action
+from cactus_client.action import execute_action, ActionResult
 from cactus_client.check import execute_checks
 from cactus_client.check.sep2 import is_invalid_resource
+from cactus_client.error import CactusClientException
 from cactus_client.model.context import ExecutionContext
-from cactus_client.model.execution import ExecutionResult
+from cactus_client.model.execution import ExecutionResult, StepExecution, CheckResult
 from cactus_client.time import utc_now
+
+from typing import AsyncIterator
 
 logger = logging.getLogger(__name__)
 
@@ -23,73 +27,119 @@ def validate_all_resources(context: ExecutionContext) -> None:
                 context.warnings.log_stored_resource_warning(sr, error)
 
 
+@asynccontextmanager
+async def setup_and_teardown(context: ExecutionContext) -> AsyncIterator[ActionResult]:
+    """Executes plugin admin setup and teardown functions as an async context manager."""
+    dummy_check_result = CheckResult(passed=True, description="No checks provided")
+
+    # Setup
+    setup_step = StepExecution.admin_setup()
+    logger.debug("====== Running admin setup ======")
+
+    try:
+        action_result = await execute_action(setup_step, context)
+        await context.progress.set_step_result(setup_step, action_result, dummy_check_result)
+        logger.debug("===== Admin setup complete =====")
+        # Yield the action result
+        yield action_result
+
+    except Exception as exc:
+        logger.error("Admin setup exception", exc_info=exc)
+        await context.progress.add_step_execution_exception(setup_step, exc)
+
+    finally:
+        # Teardown
+        logger.debug("====== Running admin teardown ======")
+        teardown_step = StepExecution.admin_teardown()
+        try:
+            action_result = await execute_action(teardown_step, context)
+            await context.progress.set_step_result(teardown_step, action_result, dummy_check_result)
+        except Exception as exc:
+            logger.error("Admin teardown exception", exc_info=exc)
+            await context.progress.add_step_execution_exception(teardown_step, exc)
+
+        logger.debug("====== Admin teardown complete ======")
+
+
 async def execute_for_context(context: ExecutionContext) -> ExecutionResult:
     """Does the actual execution work - will operate until the context's step list is fully drained. Will also
     handle updating trackers as the steps execute.
 
-    If any step reports failure - execution will be stopped"""
+    If any step reports failure - execution will be stopped.
 
-    while (upcoming_step := context.steps.peek_next_no_wait(now := utc_now())) is not None:
+    Args:
+        context: Contains all elements necessary for execution state
 
-        # Sometimes the next step will have a "not before" time - in which case we delay until that time has passed
-        # We do this via peeking so we can log the delay against that upcoming step without popping it off the queue
-        delay_required = upcoming_step.executable_delay_required(now)
-        if delay_required:
-            await context.progress.update_current_step(upcoming_step, delay=delay_required)
-            await asyncio.sleep(delay_required.total_seconds())
-            continue
-
-        # We're ready to commit to running the next step
-        current_step = context.steps.pop(now)
-        if current_step is None:
-            continue  # Shouldn't happen due to our earlier wait
-
-        # Start the step execution and checking
-        await context.progress.update_current_step(current_step, delay=None)
-        try:
-            action_result = await execute_action(current_step, context)
-        except Exception as exc:
-            logger.error("Action exception", exc_info=exc)
-            await context.progress.add_step_execution_exception(current_step, exc)
+    Returns:
+        Overall result of the test execution
+    """
+    # Context manager with the setup and teardown functionality
+    async with setup_and_teardown(context) as setup_result:
+        if not setup_result.completed:
             return ExecutionResult(completed=False)
 
-        try:
-            check_result = await execute_checks(current_step, context)
-        except Exception as exc:
-            logger.error("Check exception", exc_info=exc)
-            await context.progress.add_step_execution_exception(current_step, exc)
-            return ExecutionResult(completed=False)
+        while (upcoming_step := context.steps.peek_next_no_wait(now := utc_now())) is not None:
 
-        await context.progress.add_step_execution_completion(current_step, action_result, check_result)
+            # Sometimes the next step will have a "not before" time - in which case we delay until that time has passed
+            # We do this via peeking so we can log the delay against that upcoming step without popping it off the queue
+            delay_required = upcoming_step.executable_delay_required(now)
+            if delay_required:
+                await context.progress.update_current_step(upcoming_step, delay=delay_required)
+                await asyncio.sleep(delay_required.total_seconds())
+                continue
 
-        # Combine action and check results - step passes only if both pass
-        step_passed = action_result.completed and check_result.passed
+            # We're ready to commit to running the next step
+            current_step = context.steps.pop(now)
+            if current_step is None:
+                continue  # Shouldn't happen due to our earlier wait
 
-        # Depending on how the step ran - we may need to add a repeat or requeue
-        if step_passed and action_result.repeat:
-            # The step was successful, but asked for a repeat
-            repeat_step = replace(
-                current_step,
-                repeat_number=current_step.repeat_number + 1,
-                attempts=0,
-                not_before=action_result.not_before,
-            )
-            context.steps.add(repeat_step)
-        elif not step_passed and current_step.source.repeat_until_pass:
-            # The step failed (action or check) - but it might be marked as repeat_until_pass
-            repeat_step = replace(current_step, attempts=current_step.attempts + 1, not_before=None)
-            context.steps.add(repeat_step)
+            # Start the step execution and checking
+            await context.progress.update_current_step(current_step, delay=None)
 
-            # This can potentially result in a tight loop - so we add a delay
-            await context.progress.update_current_step(repeat_step, delay=context.repeat_delay)
-            await asyncio.sleep(context.repeat_delay.seconds)
-        else:
-            # At this point - we aren't re-queuing a repeat, therefore this step is now "done" (pass or fail)
-            await context.progress.set_step_result(current_step, action_result, check_result)
+            try:
+                action_result = await execute_action(current_step, context)
+            except Exception as exc:
+                logger.error("Action exception", exc_info=exc)
+                await context.progress.add_step_execution_exception(current_step, exc)
+                return ExecutionResult(completed=False)
 
-            # If this step failed - no point continuing, it's likely downstream steps will also fail
-            if not step_passed:
-                break
+            try:
+                check_result = await execute_checks(current_step, context)
+            except Exception as exc:
+                logger.error("Check exception", exc_info=exc)
+                await context.progress.add_step_execution_exception(current_step, exc)
+                return ExecutionResult(completed=False)
+
+            await context.progress.add_step_execution_completion(current_step, action_result, check_result)
+
+            # Combine action and check results - step passes only if both pass
+            step_passed = action_result.completed and check_result.passed
+
+            # Depending on how the step ran - we may need to add a repeat or requeue
+            if step_passed and action_result.repeat:
+                # The step was successful, but asked for a repeat
+                repeat_step = replace(
+                    current_step,
+                    repeat_number=current_step.repeat_number + 1,
+                    attempts=0,
+                    not_before=action_result.not_before,
+                )
+                context.steps.add(repeat_step)
+            elif not step_passed and current_step.source.repeat_until_pass:
+                # The step failed (action or check) - but it might be marked as repeat_until_pass
+                repeat_step = replace(current_step, attempts=current_step.attempts + 1, not_before=None)
+                context.steps.add(repeat_step)
+
+                # This can potentially result in a tight loop - so we add a delay
+                await context.progress.update_current_step(repeat_step, delay=context.repeat_delay)
+                await asyncio.sleep(context.repeat_delay.seconds)
+            else:
+                # At this point - we aren't re-queuing a repeat, therefore this step is now "done" (pass or fail)
+                await context.progress.set_step_result(current_step, action_result, check_result)
+
+                # If this step failed - no point continuing, it's likely downstream steps will also fail
+                if not step_passed:
+                    break
 
     # We do resource validation at the very end - it's easier than trying to identify resource changes after each step
     validate_all_resources(context)

--- a/src/cactus_client/execution/execute.py
+++ b/src/cactus_client/execution/execute.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 from cactus_client.action import execute_action, ActionResult
 from cactus_client.check import execute_checks
 from cactus_client.check.sep2 import is_invalid_resource
-from cactus_client.error import CactusClientException
 from cactus_client.model.context import ExecutionContext
 from cactus_client.model.execution import ExecutionResult, StepExecution, CheckResult
 from cactus_client.time import utc_now

--- a/src/cactus_client/execution/execute.py
+++ b/src/cactus_client/execution/execute.py
@@ -74,11 +74,10 @@ async def execute_for_context(context: ExecutionContext) -> ExecutionResult:
         Overall result of the test execution
     """
     # Context manager with the setup and teardown functionality
-    # async with setup_and_teardown(context) as setup_result:
-    #    if not setup_result.completed:
-    #        return ExecutionResult(completed=False)
+    async with setup_and_teardown(context) as setup_result:
+        if not setup_result.completed:
+            return ExecutionResult(completed=False)
 
-    if True:  # TODO remove temporary bridge
         while (upcoming_step := context.steps.peek_next_no_wait(now := utc_now())) is not None:
 
             # Sometimes the next step will have a "not before" time - in which case we delay until that time has passed

--- a/src/cactus_client/model/execution.py
+++ b/src/cactus_client/model/execution.py
@@ -63,6 +63,35 @@ class StepExecution:
 
         return self.not_before - now
 
+    @staticmethod
+    def admin_setup() -> "StepExecution":
+        """Default instance for use in admin setup functions."""
+        step = Step.admin_setup()
+        return StepExecution(
+            source=step,
+            client_alias=step.client or "NOT_APPLICABLE",
+            client_resources_alias=step.client or "NOT_APPLICABLE",
+            primacy=1,
+            repeat_number=0,
+            not_before=None,
+            attempts=0
+        )
+
+    @staticmethod
+    def admin_teardown() -> "StepExecution":
+        """Default instance for use in admin teardown functions."""
+        step = Step.admin_teardown()
+        return StepExecution(
+            source=step,
+            client_alias=step.client or "NOT_APPLICABLE",
+            client_resources_alias=step.client or "NOT_APPLICABLE",
+            primacy=1,
+            repeat_number=0,
+            not_before=None,
+            attempts=0
+        )
+
+
 
 class StepExecutionList:
     """Really simply "priority queue" of StepExecution elements"""

--- a/tests/unit/cactus_client/admin/test_default_impl.py
+++ b/tests/unit/cactus_client/admin/test_default_impl.py
@@ -19,7 +19,7 @@ async def test_admin_device_register(
     context: ExecutionContext
     context, step = testing_contexts_factory(mock.Mock())
 
-    pm = admin.manager.get_plugin_manager()
+    pm = admin.get_plugin_manager()
 
     # Execute
     result = await pm.ahook.admin_device_register(resolved_params={}, step=step, context=context)
@@ -38,7 +38,7 @@ async def test_admin_setup(
     context: ExecutionContext
     context, step = testing_contexts_factory(mock.Mock())
 
-    pm = admin.manager.get_plugin_manager()
+    pm = admin.get_plugin_manager()
 
     # Execute
     result = await pm.ahook.admin_setup(step=step, context=context)
@@ -57,7 +57,7 @@ async def test_admin_teardown(
     context: ExecutionContext
     context, step = testing_contexts_factory(mock.Mock())
 
-    pm = admin.manager.get_plugin_manager()
+    pm = admin.get_plugin_manager()
 
     # Execute
     result = await pm.ahook.admin_teardown(step=step, context=context)

--- a/tests/unit/cactus_client/admin/test_default_impl.py
+++ b/tests/unit/cactus_client/admin/test_default_impl.py
@@ -16,10 +16,52 @@ async def test_admin_device_register(
 ) -> None:
     """Ensure that the default implementation of the admin_device_register hook is seen"""
     # Arrange
+    context: ExecutionContext
     context, step = testing_contexts_factory(mock.Mock())
 
+    pm = admin.manager.get_plugin_manager()
+
     # Execute
-    result = await admin.manager.pm.ahook.admin_device_register({}, step, context)
+    result = await pm.ahook.admin_device_register(resolved_params={}, step=step, context=context)
 
     # Assert
-    assert result == ActionResult(completed=True, repeat=False, not_before=None)
+    assert len(result) == 1
+    assert result[0] == ActionResult(completed=True, repeat=False, not_before=None)
+
+
+@pytest.mark.asyncio
+async def test_admin_setup(
+    testing_contexts_factory: Callable[[ClientSession], tuple[ExecutionContext, StepExecution]],
+) -> None:
+    """Ensure that the default implementation of teh admin_setup hook is seen"""
+    # Arrange
+    context: ExecutionContext
+    context, step = testing_contexts_factory(mock.Mock())
+
+    pm = admin.manager.get_plugin_manager()
+
+    # Execute
+    result = await pm.ahook.admin_setup(step=step, context=context)
+
+    # Assert
+    assert len(result) == 1
+    assert result[0] == ActionResult(completed=True, repeat=False, not_before=None)
+
+
+@pytest.mark.asyncio
+async def test_admin_teardown(
+    testing_contexts_factory: Callable[[ClientSession], tuple[ExecutionContext, StepExecution]],
+) -> None:
+    """Ensure that the default implementation of the admin_teardown hook is seen"""
+    # Arrange
+    context: ExecutionContext
+    context, step = testing_contexts_factory(mock.Mock())
+
+    pm = admin.manager.get_plugin_manager()
+
+    # Execute
+    result = await pm.ahook.admin_teardown(step=step, context=context)
+
+    # Assert
+    assert len(result) == 1
+    assert result[0] == ActionResult(completed=True, repeat=False, not_before=None)

--- a/tests/unit/cactus_client/admin/test_default_impl.py
+++ b/tests/unit/cactus_client/admin/test_default_impl.py
@@ -1,0 +1,25 @@
+import unittest.mock as mock
+
+import pytest
+from aiohttp import ClientSession
+
+from cactus_client import admin
+from cactus_client.model.context import ExecutionContext
+from cactus_client.model.execution import StepExecution, ActionResult
+
+from typing import Callable
+
+
+@pytest.mark.asyncio
+async def test_admin_device_register(
+    testing_contexts_factory: Callable[[ClientSession], tuple[ExecutionContext, StepExecution]],
+) -> None:
+    """Ensure that the default implementation of the admin_device_register hook is seen"""
+    # Arrange
+    context, step = testing_contexts_factory(mock.Mock())
+
+    # Execute
+    result = await admin.manager.pm.ahook.admin_device_register({}, step, context)
+
+    # Assert
+    assert result == ActionResult(completed=True, repeat=False, not_before=None)

--- a/tests/unit/cactus_client/execution/test_execute.py
+++ b/tests/unit/cactus_client/execution/test_execute.py
@@ -50,10 +50,15 @@ ACTION_REPEAT_ONCE_DELAY = "action-repeat-once-delay"
 ACTION_EXCEPTION = "action-exception"
 ACTION_FAIL_ONCE = "action-fail-once"  # Returns ActionResult.failed() on first attempt, then done()
 
+ACTION_ADMIN_SETUP = "admin-setup"
+ACTION_ADMIN_TEARDOWN = "admin-teardown"
+
 CHECK_FAIL_ONCE = "check-fail-once"
 CHECK_PASS = "check-pass"
 CHECK_FAIL = "check-fail"
 CHECK_EXCEPTION = "check-exception"
+
+TEST_PROCEDURES_VERSION_ADMIN_SETUP_FAIL = "admin-setup-failure-test"
 
 
 DELAY_TIME = timedelta(seconds=2)
@@ -84,6 +89,12 @@ def handle_mock_execute_action(current_step: StepExecution, context: ExecutionCo
             return ActionResult.failed("Retriable failure on first attempt")
         else:
             return ActionResult.done()
+    elif (
+        context.test_procedures_version == TEST_PROCEDURES_VERSION_ADMIN_SETUP_FAIL and action_type == ACTION_ADMIN_SETUP
+    ):
+        return ActionResult.failed("mocked admin setup failure")
+    elif action_type in [ACTION_ADMIN_SETUP, ACTION_ADMIN_TEARDOWN]:
+        return ActionResult.done()
     else:
         raise NotImplementedError(f"Unsupported action type {action_type}")
 
@@ -200,7 +211,8 @@ async def test_execute_for_context_success_cases_with_repeats(
     assert duration <= DELAY_TIME, "We expect the test to operate with no delays"
 
     assert mock_execute_checks.call_count == 5
-    assert mock_execute_action.call_count == 5
+    # Call counts include setup and teardown
+    assert mock_execute_action.call_count == 5 + 2
 
     assert len(context.warnings.warnings) == 0
 
@@ -280,7 +292,8 @@ async def test_execute_for_context_action_failed_with_repeat_until_pass(
     assert result.completed
 
     # Step 1 runs twice (fails on first attempt), step 2 runs once
-    assert mock_execute_action.call_count == 3
+    # Call counts include setup and teardown
+    assert mock_execute_action.call_count == 3 + 2
     assert mock_execute_checks.call_count == 3
 
     assert [se.step_execution.source.id for se in context.progress.all_completions] == ["1", "1", "2"]
@@ -357,7 +370,8 @@ async def test_execute_for_context_action_failed_without_repeat_stops_early(
     assert result.completed  # completed=True means no exception, even though step failed
 
     # Only step 1 runs, and it fails (action returned failed), step 2 never runs
-    assert mock_execute_action.call_count == 1
+    # Call counts include setup and teardown (+2)
+    assert mock_execute_action.call_count == 1 + 2
     assert mock_execute_checks.call_count == 1
 
     assert [se.step_execution.source.id for se in context.progress.all_completions] == ["1"]
@@ -444,7 +458,8 @@ async def test_execute_for_context_failure_stops_early(
     assert result.completed
 
     assert mock_execute_checks.call_count == 2, "Only the first two steps should execute due to step 2 failing"
-    assert mock_execute_action.call_count == 2, "Only the first two steps should execute due to step 2 failing"
+    # Call counts include setup and teardown (+2)
+    assert mock_execute_action.call_count == 2 + 2, "Only the first two steps should execute due to step 2 failing"
 
     assert [se.step_execution.source.id for se in context.progress.all_completions] == ["1", "2"]
     assert [p.is_success() for p in context.progress.all_completions] == [True, False]
@@ -531,7 +546,8 @@ async def test_execute_for_context_action_exception(
     assert not result.completed
 
     assert mock_execute_checks.call_count == 1, "Test is aborted at step 2 (during action execution)"
-    assert mock_execute_action.call_count == 2, "Test is aborted at step 2"
+    # Call count includes setup and teardown (+2)
+    assert mock_execute_action.call_count == 2 + 2, "Test is aborted at step 2"
 
     assert len(context.warnings.warnings) == 0
     assert [se.step_execution.source.id for se in context.progress.all_completions] == ["1", "2"]
@@ -706,7 +722,8 @@ async def test_execute_for_context_success_cases_with_delays(
     assert_step_result(context.progress, "2", True)
 
     assert mock_execute_checks.call_count == 3
-    assert mock_execute_action.call_count == 3
+    # Calls include setup and teardown (+2)
+    assert mock_execute_action.call_count == 3 + 2
     assert len(context.warnings.warnings) == 0
 
 
@@ -847,3 +864,69 @@ def test_validate_all_resources(resources: list[tuple[CSIPAusResource, Resource]
         validate_all_resources(context)
         readable_warnings = "\n".join([w.message for w in context.warnings.warnings])
         assert len(context.warnings.warnings) == expected_warnings, readable_warnings
+
+
+@mock.patch("cactus_client.execution.execute.execute_action")
+@mock.patch("cactus_client.execution.execute.execute_checks")
+@pytest.mark.asyncio
+async def test_setup_and_teardown_setup_fails(
+    mock_execute_checks: mock.MagicMock,
+    mock_execute_action: mock.MagicMock,
+):
+    """Can execute handle cases where some steps repeat due to failure or by request"""
+    # Arrange
+    step_list = StepExecutionList()
+    step_list.add(
+        StepExecution(
+            Step(id="2", action=Action(ACTION_DONE), checks=[Check(CHECK_PASS)]),
+            client_alias="client-test",
+            client_resources_alias="client-test",
+            primacy=1,
+            repeat_number=0,
+            not_before=None,
+            attempts=0,
+        )
+    )
+
+    tree = CSIPAusResourceTree()
+    context = ExecutionContext(
+        test_procedure_id=TestProcedureId.S_ALL_01,
+        test_procedure=generate_class_instance(TestProcedure),
+        test_procedures_version=TEST_PROCEDURES_VERSION_ADMIN_SETUP_FAIL,
+        output_directory=Path("."),  # Shouldn't be used to do anything in this test
+        dcap_path="/dcap/path",
+        server_config=generate_class_instance(ServerConfig),
+        clients_by_alias={
+            "client-test": ClientContext(
+                "client-test", generate_class_instance(ClientConfig), ResourceStore(tree), {}, mock.Mock(), None
+            )
+        },
+        resource_tree=tree,
+        repeat_delay=timedelta(0),
+        responses=ResponseTracker(),
+        warnings=WarningTracker(),
+        progress=ProgressTracker(),
+        steps=step_list,
+    )
+
+    mock_execute_checks.side_effect = handle_mock_execute_checks
+    mock_execute_action.side_effect = handle_mock_execute_action
+
+    # Act
+    result = await execute_for_context(context)
+
+    # Assert
+    assert isinstance(result, ExecutionResult)
+
+    assert mock_execute_checks.call_count == 0
+    # Call counts include setup and teardown (+2)
+    assert mock_execute_action.call_count == 0 + 2
+
+    assert len(context.warnings.warnings) == 0
+
+    assert [se.step_execution.source.id for se in context.progress.all_completions] == []
+    assert [p.is_success() for p in context.progress.all_completions] == []
+
+    for p in context.progress.all_completions:
+        assert_nowish(p.created_at)
+        assert p.exc is None


### PR DESCRIPTION
This is what I have in mind for a plugin interface using pluggy (well apluggy since there isn't native async support for pluggy just yet). 

The idea here is that all people that have admin api interaction libraries can easily define admin actions using them. The test procedures declare their calls in the yamls. 

Included with the cactus-client is the default implementation (hookimpl) which always returns a positive result for each action. 

Setup and Teardown hooks are created, called upon via an async context manager via the execute module. 

This relates to https://github.com/bsgip/cactus-test-definitions/pull/140 and in this implementation i have temporarily included it as a dependency.    