### PR TITLE
feat(action): allow for 204 no content returns on resources

### DIFF
--- a/src/cactus_client/action/discovery.py
+++ b/src/cactus_client/action/discovery.py
@@ -161,6 +161,10 @@ async def discover_resource(
         for parent_sr in resource_store.get_for_type(parent_resource):
             href = parent_sr.resource_link_hrefs.get(resource, None)
             if href:
+                resource_for_step = await get_resource_for_step(RESOURCE_SEP2_TYPES[resource], step, context, href)
+                # This caters for a no content 204 response
+                if resource_for_step is None:
+                    continue
                 resource_store.append_resource(
                     resource,
                     parent_sr.id,
@@ -168,7 +172,7 @@ async def discover_resource(
                         step,
                         context,
                         href,
-                        await get_resource_for_step(RESOURCE_SEP2_TYPES[resource], step, context, href),
+                        resource_for_step,
                     ),
                 )
 

--- a/src/cactus_client/action/discovery.py
+++ b/src/cactus_client/action/discovery.py
@@ -22,7 +22,7 @@ from cactus_client.action.server import (
     get_resource_for_step,
     paginate_list_resource_items,
 )
-from cactus_client.error import CactusClientException
+from cactus_client.error import CactusClientException, StateException
 from cactus_client.model.context import ExecutionContext
 from cactus_client.model.execution import ActionResult, StepExecution
 from cactus_client.model.resource import RESOURCE_SEP2_TYPES, ResourceStore
@@ -111,6 +111,11 @@ async def discover_resource(
     # We need to also check if the parent resource is a list type and this resource is a member of that list
     parent_resource = context.resource_tree.parent_resource(resource)
     if parent_resource is None:
+        dcap_resource = await get_resource_for_step(DeviceCapabilityResponse, step, context, context.dcap_path)
+        if dcap_resource is None:
+            # Unlikely but included for completeness
+            raise StateException(f"{context.dcap_path} returned no content")
+
         # We have device capability - this is a special case
         resource_store.append_resource(
             CSIPAusResource.DeviceCapability,
@@ -119,7 +124,7 @@ async def discover_resource(
                 step,
                 context,
                 context.dcap_path,
-                await get_resource_for_step(DeviceCapabilityResponse, step, context, context.dcap_path),
+                dcap_resource
             ),
         )
         return

--- a/src/cactus_client/action/discovery.py
+++ b/src/cactus_client/action/discovery.py
@@ -120,12 +120,7 @@ async def discover_resource(
         resource_store.append_resource(
             CSIPAusResource.DeviceCapability,
             None,
-            check_item_for_href(
-                step,
-                context,
-                context.dcap_path,
-                dcap_resource
-            ),
+            check_item_for_href(step, context, context.dcap_path, dcap_resource),
         )
         return
 

--- a/src/cactus_client/action/refresh_resource.py
+++ b/src/cactus_client/action/refresh_resource.py
@@ -33,7 +33,7 @@ async def action_refresh_resource(
     if len(matching_resources) == 0:
         raise CactusClientException(f"Expected matching resources to refresh for resource {resource_type}. None found.")
 
-    for sr in matching_resources:
+    for sr in matching_resources[:]:
         href = sr.resource.href
 
         if href is None:  # Skip resources without a href
@@ -52,7 +52,11 @@ async def action_refresh_resource(
             else:
                 # If not expected to fail, actually request the resource and upsert in the resource store
                 fetched_resource = await get_resource_for_step(type(sr.resource), step, context, href)
-                resource_store.upsert_resource(resource_type, sr.id.parent_id(), fetched_resource)
+                if fetched_resource is None:
+                    # Likely a 204 No Content has been returned so may need to remove any existing resources
+                    resource_store.delete_resource(sr.id)
+                else:
+                    resource_store.upsert_resource(resource_type, sr.id.parent_id(), fetched_resource)
 
         except RequestException as exc:
             # We will bundle up RequestException as a "retryable" failure

--- a/src/cactus_client/action/server.py
+++ b/src/cactus_client/action/server.py
@@ -8,7 +8,7 @@ from envoy_schema.server.schema.sep2.error import ErrorResponse
 from envoy_schema.server.schema.sep2.identification import List, Resource
 
 from cactus_client.constants import MIME_TYPE_SEP2
-from cactus_client.error import RequestException
+from cactus_client.error import RequestException, StateException
 from cactus_client.model.context import ExecutionContext
 from cactus_client.model.execution import StepExecution
 from cactus_client.model.http import ServerResponse
@@ -164,14 +164,28 @@ async def client_error_or_empty_list_request_for_step(
 
 async def get_resource_for_step(
     t: type[AnyResourceType], step: StepExecution, context: ExecutionContext, href: str
-) -> AnyResourceType:
-    """Makes a GET request for a particular href and parses the resulting XML into an expected type (t). Raises a
-    RequestException if the connection fails, returns an error or fails to parse to t"""
+) -> AnyResourceType | None:
+    """Makes a GET request for a particular href and parses the resulting XML into an expected type (t).
+
+    Args:
+        t: model class the response body should parse to
+        step: data object for step execution
+        context: context object for test execution
+        href: url path of the resource
+
+    Returns:
+        parsed xml model of type t or None if No Content (204)
+
+    Raises:
+        RequestException if the connection fails, returns an error or fails to parse to t
+    """
     # Make the raw request
     response = await request_for_step(step, context, href, HTTPMethod.GET)
 
     if not response.is_success():
         raise RequestException(f"Received status {response.status} requesting {response.method} {href}.")
+    if response.is_no_content():
+        return None
 
     return parse_type_response(t, response)
 
@@ -236,6 +250,8 @@ async def submit_and_refetch_resource_for_step(
 
     # Check the returned resource matches the submitted resource
     returned_resource = await get_resource_for_step(t, step, context, refetch_href)
+    if returned_resource is None:
+        raise StateException("No matching resource found for submitted request on server.")
     changes = get_property_changes(submitted_resource, returned_resource)
     if changes:
         context.warnings.log_step_warning(
@@ -341,7 +357,7 @@ async def fetch_list_page(
     """
     page_href = list_href + build_paging_params(start=start, limit=limit)
     latest_list = await get_resource_for_step(list_type, step, context, page_href)
-    latest_items = item_callback(latest_list)
+    latest_items = item_callback(latest_list) if latest_list is not None else None
     if latest_items is None:
         latest_items = []  # pydantic-xml can parse a missing/empty list as None
 

--- a/src/cactus_client/error.py
+++ b/src/cactus_client/error.py
@@ -20,3 +20,9 @@ class NotificationException(CactusClientException):
     """Something went wrong when interacting with the remote CACTUS Client Notification server."""
 
     pass
+
+
+class StateException(CactusClientException):
+    """A irreconcilable state difference between the server and CactusClient was found."""
+
+    pass

--- a/src/cactus_client/model/http.py
+++ b/src/cactus_client/model/http.py
@@ -63,6 +63,9 @@ class ServerResponse:
     def is_success(self) -> bool:
         return self.status >= 200 and self.status < 300
 
+    def is_no_content(self) -> bool:
+        return self.status == 204
+
     def is_client_error(self) -> bool:
         return self.status >= 400 and self.status < 500
 

--- a/tests/unit/cactus_client/action/test_discovery.py
+++ b/tests/unit/cactus_client/action/test_discovery.py
@@ -13,7 +13,7 @@ from cactus_client.action.discovery import (
     calculate_wait_next_polling_window,
     discover_resource,
 )
-from cactus_client.error import CactusClientException
+from cactus_client.error import CactusClientException, StateException
 from cactus_client.model.context import ExecutionContext
 from cactus_client.model.execution import StepExecution
 from cactus_client.model.resource import RESOURCE_SEP2_TYPES
@@ -87,6 +87,31 @@ async def test_discover_resource_dcap(
     else:
         assert len(context.warnings.warnings) == 1
         assert len(stored_resources) == 0
+
+
+@mock.patch("cactus_client.action.discovery.get_resource_for_step")
+@mock.patch("cactus_client.action.discovery.paginate_list_resource_items")
+@pytest.mark.asyncio
+async def test_discover_resource_dcap_no_content(
+    mock_paginate_list_resource_items: mock.MagicMock,
+    mock_get_resource_for_step: mock.MagicMock,
+    testing_contexts_factory: Callable[[ClientSession], tuple[ExecutionContext, StepExecution]],
+):
+    """DeviceCapability when a no-content is returned"""
+
+    # Arrange
+    context, step = testing_contexts_factory(mock.Mock())
+    mock_get_resource_for_step.return_value = None
+
+    with pytest.raises(StateException):
+        await discover_resource(CSIPAusResource.DeviceCapability, step, context, None)
+
+    # Assert
+    stored_resources = context.discovered_resources(step).get_for_type(CSIPAusResource.DeviceCapability)
+    mock_get_resource_for_step.assert_called_once_with(DeviceCapabilityResponse, step, context, context.dcap_path)
+    mock_paginate_list_resource_items.assert_not_called()
+
+    assert len(stored_resources) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cactus_client/action/test_discovery.py
+++ b/tests/unit/cactus_client/action/test_discovery.py
@@ -239,6 +239,42 @@ async def test_discover_resource_singular_resources(
 
 
 @pytest.mark.parametrize(
+    "resource, matched_parents",
+    [(CSIPAusResource.DefaultDERControl, 1)],
+)
+@mock.patch("cactus_client.action.discovery.get_resource_for_step")
+@mock.patch("cactus_client.action.discovery.paginate_list_resource_items")
+@pytest.mark.asyncio
+async def test_discover_resource_singular_resource_no_content(
+    mock_paginate_list_resource_items: mock.MagicMock,
+    mock_get_resource_for_step: mock.MagicMock,
+    testing_contexts_factory: Callable[[ClientSession], tuple[ExecutionContext, StepExecution]],
+    resource: CSIPAusResource,
+    matched_parents: int,
+):
+    """
+    Discover singular resources via parent link (e.g. DefaultDERControl), with no-content returned
+
+    Tests 1-to-1 parent-child relationships. Uses get_resource_for_step, not pagination.
+    """
+    # Arrange
+    context, step, resource_store, _, _ = setup_discovery_test(testing_contexts_factory, resource, matched_parents)
+    mock_get_resource_for_step.return_value = None
+
+    # Act
+    await discover_resource(resource, step, context, None)
+
+    # Assert
+    added_resources = resource_store.get_for_type(resource)
+    assert [sr.resource for sr in added_resources] == []
+
+    mock_get_resource_for_step.assert_called()
+    mock_paginate_list_resource_items.assert_not_called()
+
+    assert len(context.warnings.warnings) == 0
+
+
+@pytest.mark.parametrize(
     "list_resource, child_resource, num_parents, items_per_parent",
     [
         (CSIPAusResource.MirrorUsagePointList, CSIPAusResource.MirrorUsagePoint, 1, [3]),

--- a/tests/unit/cactus_client/action/test_refresh_resource.py
+++ b/tests/unit/cactus_client/action/test_refresh_resource.py
@@ -67,6 +67,50 @@ async def test_action_refresh_resource_happy_path(testing_contexts_factory):
 
 
 @pytest.mark.asyncio
+async def test_action_refresh_resource_existing_resource_now_none(testing_contexts_factory):
+    """Makes sure when a get_resource_for_step returns None and resource exists it gets deleted."""
+
+    # Arrange
+    context: ExecutionContext
+    context, step = testing_contexts_factory(mock.Mock())
+    resource_store = context.discovered_resources(step)
+
+    # Create multiple EndDevices in the store
+    edev1 = generate_class_instance(EndDeviceResponse, href="/edev/1", postRate=60)
+    edev2 = generate_class_instance(EndDeviceResponse, href="/edev/2", postRate=60)
+    resource_store.upsert_resource(CSIPAusResource.EndDevice, None, edev1)
+    resource_store.upsert_resource(CSIPAusResource.EndDevice, None, edev2)
+
+    with mock.patch("cactus_client.action.refresh_resource.get_resource_for_step") as mock_get:
+        # Return none from the function
+        mock_get.return_value = None
+
+        resolved_params = {"resource": CSIPAusResource.EndDevice.value}
+        current_contents = resource_store.get_for_type(CSIPAusResource.EndDevice)
+        assert len(current_contents) == 2
+
+        # Act
+        result = await action_refresh_resource(resolved_params, step, context)
+
+        # Assert
+        assert isinstance(result, ActionResult)
+        assert result.completed
+
+        # Verify get_resource_for_step was called twice
+        assert mock_get.call_count == 2
+
+        # Check first call in detail
+        first_call_args = mock_get.call_args_list[0]
+        assert first_call_args[0][0] == EndDeviceResponse
+        assert first_call_args[0][2] == context
+        assert first_call_args[0][3] == "/edev/1"
+
+        # Verify both resources were deleted
+        stored_edevs = resource_store.get_for_type(CSIPAusResource.EndDevice)
+        assert len(stored_edevs) == 0
+
+
+@pytest.mark.asyncio
 async def test_action_refresh_resource_expect_rejection(testing_contexts_factory):
 
     # Arrange

--- a/tests/unit/cactus_client/action/test_server.py
+++ b/tests/unit/cactus_client/action/test_server.py
@@ -33,7 +33,7 @@ from cactus_client.action.server import (
     submit_and_refetch_resource_for_step,
 )
 from cactus_client.constants import MIME_TYPE_SEP2
-from cactus_client.error import RequestException
+from cactus_client.error import RequestException, StateException
 
 
 @dataclass
@@ -186,6 +186,28 @@ async def test_get_resource_for_step_success(aiohttp_client, testing_contexts_fa
     assert isinstance(result, DeviceCapabilityResponse)
     assert result.EndDeviceListLink.all_ == 2
     assert result.EndDeviceListLink.href == "/envoy-svc-static-36/edev"
+
+    # Assert - contents of trackers
+    assert len(execution_context.warnings.warnings) == 0
+    assert len(execution_context.responses.responses) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_resource_for_step_no_content(aiohttp_client, testing_contexts_factory):
+    """Does get_resource_for_step handle parsing the XML and returning the correct data"""
+    async with create_test_session(
+        aiohttp_client,
+        [
+            TestingAppRoute(
+                HTTPMethod.GET, "/foo/bar", [RouteBehaviour.no_content_location(HTTPStatus.NO_CONTENT, "/foo/bar/baz")]
+            )
+        ],
+    ) as session:
+        execution_context, step_execution = testing_contexts_factory(session)
+        result = await get_resource_for_step(DeviceCapabilityResponse, step_execution, execution_context, "/foo/bar")
+
+    # Assert - contents of response
+    assert result is None
 
     # Assert - contents of trackers
     assert len(execution_context.warnings.warnings) == 0
@@ -435,6 +457,35 @@ async def test_submit_and_refetch_resource_for_step_failure_refetch_request(aioh
                 execution_context,
                 HTTPMethod.DELETE,
                 "/foo",
+                generate_class_instance(DeviceCapabilityResponse),
+            )
+
+
+@mock.patch("cactus_client.action.server.get_resource_for_step")
+@pytest.mark.asyncio
+async def test_submit_and_refetch_resource_for_step_returned_resource_none(
+    mock_get_resource_for_step, aiohttp_client, testing_contexts_factory
+):
+    """Does submit_and_refetch_resource_for_step abort if the refetch request fails"""
+    async with create_test_session(
+        aiohttp_client,
+        [
+            TestingAppRoute(HTTPMethod.PUT, "/foo/bar", [RouteBehaviour.no_content_location(HTTPStatus.OK, "/foo/bar")]),
+            TestingAppRoute(
+                HTTPMethod.GET, "/foo/bar", [RouteBehaviour.no_content_location(HTTPStatus.NO_CONTENT, "/foo/bar")]
+            ),
+        ],
+    ) as session:
+        execution_context, step_execution = testing_contexts_factory(session)
+        mock_get_resource_for_step.return_value = None
+
+        with pytest.raises(StateException):
+            await submit_and_refetch_resource_for_step(
+                DeviceCapabilityResponse,
+                step_execution,
+                execution_context,
+                HTTPMethod.PUT,
+                "/foo/bar",
                 generate_class_instance(DeviceCapabilityResponse),
             )
 

--- a/tests/unit/cactus_client/action/test_server.py
+++ b/tests/unit/cactus_client/action/test_server.py
@@ -470,7 +470,9 @@ async def test_submit_and_refetch_resource_for_step_returned_resource_none(
     async with create_test_session(
         aiohttp_client,
         [
-            TestingAppRoute(HTTPMethod.PUT, "/foo/bar", [RouteBehaviour.no_content_location(HTTPStatus.OK, "/foo/bar")]),
+            TestingAppRoute(
+                HTTPMethod.PUT, "/foo/bar", [RouteBehaviour.no_content_location(HTTPStatus.OK, "/foo/bar")]
+            ),
             TestingAppRoute(
                 HTTPMethod.GET, "/foo/bar", [RouteBehaviour.no_content_location(HTTPStatus.NO_CONTENT, "/foo/bar")]
             ),


### PR DESCRIPTION
This enables the ability to test servers that return 204 when resources with hrefs aren't yet created, e.g. default der controls. This is highlighted as the preferred way to represent such situations as per IEEE2030.5:2018 section 5.5.2.5. 

I have made it that when a None is returned from `get_resource_for_step` from within `action_refresh_resource` it deletes the resource. I'm making the leap here that when something exists and is nullified it is then removed from the resource tree. If that can even happen i'm not sure. 

Have run S-ALL-49 on our server tests which now allows for this test to pass (it doesn't setup a DDERC on one of the DERPS which was causing discovery to raise an exception, attempting to parse a null body). 

