### PR TITLE
configurable_nmi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ name = "cactus_client"
 dynamic = ["version", "readme"]
 description = "Tools for evaluating a CSIP Aus server implementation via a virtual client"
 dependencies = [
-    "cactus-test-definitions==1.10.4",
+    "cactus-test-definitions==1.13.1",
     "cactus-schema>=0.0.11",
     "envoy-schema>=0.31.1",
     "rich>=14.1.0,<15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ description = "Tools for evaluating a CSIP Aus server implementation via a virtu
 dependencies = [
     "cactus-test-definitions==1.13.1",
     "cactus-schema>=0.0.11",
-    "envoy-schema>=0.31.1",
+    "envoy-schema>=1.1.0,<2",
     "rich>=14.1.0,<15",
     "treelib>=1.8.0,<2",
     "aiohttp>=3.11.12,<4",

--- a/src/cactus_client/action/discovery.py
+++ b/src/cactus_client/action/discovery.py
@@ -15,6 +15,12 @@ from envoy_schema.server.schema.sep2.function_set_assignments import (
 )
 from envoy_schema.server.schema.sep2.identification import Resource
 from envoy_schema.server.schema.sep2.metering_mirror import MirrorUsagePointListResponse
+from envoy_schema.server.schema.sep2.pricing import (
+    ConsumptionTariffIntervalListResponse,
+    RateComponentListResponse,
+    TariffProfileListResponse,
+    TimeTariffIntervalListResponse,
+)
 from envoy_schema.server.schema.sep2.pub_sub import SubscriptionListResponse
 
 from cactus_client.action.server import (
@@ -25,7 +31,7 @@ from cactus_client.action.server import (
 from cactus_client.error import CactusClientException
 from cactus_client.model.context import ExecutionContext
 from cactus_client.model.execution import ActionResult, StepExecution
-from cactus_client.model.resource import RESOURCE_SEP2_TYPES, ResourceStore
+from cactus_client.model.resource import RESOURCE_SEP2_TYPES, CombinedTimeTariffIntervalListResponse, ResourceStore
 from cactus_client.time import utc_now
 
 DISCOVERY_LIST_PAGE_SIZE = 3  # We want something suitably small (to ensure pagination is tested)
@@ -90,6 +96,21 @@ def get_list_item_callback(
         case CSIPAusResource.SubscriptionList:
             get_list_items = lambda list_: cast(SubscriptionListResponse, list_).subscriptions  # type: ignore # noqa: E731
             list_item_type = CSIPAusResource.Subscription
+        case CSIPAusResource.TariffProfileList:
+            get_list_items = lambda list_: cast(TariffProfileListResponse, list_).TariffProfile  # type: ignore # noqa: E731
+            list_item_type = CSIPAusResource.TariffProfile
+        case CSIPAusResource.RateComponentList:
+            get_list_items = lambda list_: cast(RateComponentListResponse, list_).RateComponent  # type: ignore # noqa: E731
+            list_item_type = CSIPAusResource.RateComponent
+        case CSIPAusResource.TimeTariffIntervalList:
+            get_list_items = lambda list_: cast(TimeTariffIntervalListResponse, list_).TimeTariffInterval  # type: ignore # noqa: E731
+            list_item_type = CSIPAusResource.TimeTariffInterval
+        case CSIPAusResource.CombinedTimeTariffIntervalList:
+            get_list_items = lambda list_: cast(CombinedTimeTariffIntervalListResponse, list_).TimeTariffInterval  # type: ignore # noqa: E731
+            list_item_type = CSIPAusResource.TimeTariffInterval
+        case CSIPAusResource.ConsumptionTariffIntervalList:
+            get_list_items = lambda list_: cast(ConsumptionTariffIntervalListResponse, list_).ConsumptionTariffInterval  # type: ignore # noqa: E731
+            list_item_type = CSIPAusResource.ConsumptionTariffInterval
 
     if get_list_items is None or list_item_type is None:
         raise CactusClientException(f"resource {list_resource} has no registered get_list_items function.")

--- a/src/cactus_client/cli/client.py
+++ b/src/cactus_client/cli/client.py
@@ -37,6 +37,8 @@ class ClientConfigKey(StrEnum):
     PEN = auto()
     PIN = auto()
     MAXW = auto()
+    NMI = auto()
+    NMI_2 = auto()
     USER_AGENT = auto()
 
 
@@ -87,6 +89,10 @@ def print_client_value(console: Console, client: ClientConfig | None, config_key
             value = client.type
         case ClientConfigKey.MAXW:
             value = client.max_watts
+        case ClientConfigKey.NMI:
+            value = client.nmi
+        case ClientConfigKey.NMI_2:
+            value = client.nmi_2
         case ClientConfigKey.PEN:
             value = client.pen
         case ClientConfigKey.PIN:
@@ -130,6 +136,10 @@ def update_client_value(
                 return replace(client, type=ClientType(new_value))
             case ClientConfigKey.MAXW:
                 return replace(client, max_watts=int(new_value))
+            case ClientConfigKey.NMI:
+                return replace(client, nmi=new_value)
+            case ClientConfigKey.NMI_2:
+                return replace(client, nmi_2=new_value)
             case ClientConfigKey.PEN:
                 return replace(client, pen=int(new_value))
             case ClientConfigKey.PIN:
@@ -175,6 +185,10 @@ def print_client(console: Console, client: ClientConfig) -> None:
         "max_watts",
         str(client.max_watts),
         "When registering a [b]DERCapability[/] and [b]DERSettings[/], use this value for max watts.",
+    )
+    table.add_row("nmi", client.nmi, "Any valid NMI for [b]ConnectionPoint[/] registration ($(valid_nmi_1))")
+    table.add_row(
+        "nmi_2", client.nmi_2, "Any other  valid NMI for tests that update a [b]ConnectionPoint[/] ($(valid_nmi_2))"
     )
     table.add_row("pen", str(client.pen), "The IANA private enterprise number of this client. Used for [b]mRID's[/]")
     table.add_row(

--- a/src/cactus_client/model/config.py
+++ b/src/cactus_client/model/config.py
@@ -62,6 +62,8 @@ class ClientConfig:
     pen: int  # Private Enterprise Number that this client will utilise
     pin: int  # Registration PIN that this client will treat as "valid"
     max_watts: int  # How many watts will be registered by this client (eg setMaxW rtgMaxW) with the utility server
+    nmi: str = "41020000002"  # Any valid NMI for ConnectionPoint registration
+    nmi_2: str = "41020000026"  # Any other valid nmi for tests that update a ConnectionPoint
     user_agent: str | None = None  # What User-Agent header should be sent by this client (if any)
 
 

--- a/src/cactus_client/model/parameter.py
+++ b/src/cactus_client/model/parameter.py
@@ -34,6 +34,10 @@ async def resolve_variable(client_config: ClientConfig, v: NamedVariable | Expre
                 return utc_now()
             case NamedVariableType.DERSETTING_SET_MAX_W:
                 return client_config.max_watts
+            case NamedVariableType.NMI_1:
+                return client_config.nmi
+            case NamedVariableType.NMI_2:
+                return client_config.nmi_2
         raise UnresolvableVariableError(f"Unable to resolve NamedVariable of type {v.variable} ({int(v.variable)})")
     elif isinstance(v, Expression):
         lhs = await resolve_variable(client_config, v.lhs_operand)

--- a/src/cactus_client/model/resource.py
+++ b/src/cactus_client/model/resource.py
@@ -37,6 +37,16 @@ from envoy_schema.server.schema.sep2.pub_sub import (
     Subscription,
     SubscriptionListResponse,
 )
+from envoy_schema.server.schema.sep2.pricing import (
+    ConsumptionTariffIntervalListResponse,
+    ConsumptionTariffIntervalResponse,
+    RateComponentListResponse,
+    RateComponentResponse,
+    TariffProfileListResponse,
+    TariffProfileResponse,
+    TimeTariffIntervalListResponse,
+    TimeTariffIntervalResponse,
+)
 from envoy_schema.server.schema.sep2.time import TimeResponse
 from treelib import Tree
 
@@ -46,6 +56,10 @@ from cactus_client.time import utc_now
 logger = logging.getLogger(__name__)
 
 AnyType = TypeVar("AnyType")
+
+
+class CombinedTimeTariffIntervalListResponse(TimeTariffIntervalListResponse):
+    """CSIP-Aus extension of TimeTariffIntervalList combining all intervals across RateComponents for a TariffProfile."""
 
 
 RESOURCE_SEP2_TYPES: dict[CSIPAusResource, type[Resource]] = {
@@ -72,6 +86,15 @@ RESOURCE_SEP2_TYPES: dict[CSIPAusResource, type[Resource]] = {
     CSIPAusResource.DERSettings: DERSettings,
     CSIPAusResource.DERStatus: DERStatus,
     CSIPAusResource.Notification: Notification,  # Not in the resource tree
+    CSIPAusResource.TariffProfileList: TariffProfileListResponse,
+    CSIPAusResource.TariffProfile: TariffProfileResponse,
+    CSIPAusResource.RateComponentList: RateComponentListResponse,
+    CSIPAusResource.RateComponent: RateComponentResponse,
+    CSIPAusResource.CombinedTimeTariffIntervalList: CombinedTimeTariffIntervalListResponse,
+    CSIPAusResource.TimeTariffIntervalList: TimeTariffIntervalListResponse,
+    CSIPAusResource.TimeTariffInterval: TimeTariffIntervalResponse,
+    CSIPAusResource.ConsumptionTariffIntervalList: ConsumptionTariffIntervalListResponse,
+    CSIPAusResource.ConsumptionTariffInterval: ConsumptionTariffIntervalResponse,
 }
 
 
@@ -106,6 +129,25 @@ class CSIPAusResourceTree:
         self.tree.create_node(identifier=CSIPAusResource.DERCapability, parent=CSIPAusResource.DER)
         self.tree.create_node(identifier=CSIPAusResource.DERSettings, parent=CSIPAusResource.DER)
         self.tree.create_node(identifier=CSIPAusResource.DERStatus, parent=CSIPAusResource.DER)
+        self.tree.create_node(
+            identifier=CSIPAusResource.TariffProfileList, parent=CSIPAusResource.FunctionSetAssignments
+        )
+        self.tree.create_node(identifier=CSIPAusResource.TariffProfile, parent=CSIPAusResource.TariffProfileList)
+        self.tree.create_node(identifier=CSIPAusResource.RateComponentList, parent=CSIPAusResource.TariffProfile)
+        self.tree.create_node(identifier=CSIPAusResource.RateComponent, parent=CSIPAusResource.RateComponentList)
+        self.tree.create_node(
+            identifier=CSIPAusResource.CombinedTimeTariffIntervalList, parent=CSIPAusResource.TariffProfile
+        )
+        self.tree.create_node(identifier=CSIPAusResource.TimeTariffIntervalList, parent=CSIPAusResource.RateComponent)
+        self.tree.create_node(
+            identifier=CSIPAusResource.TimeTariffInterval, parent=CSIPAusResource.TimeTariffIntervalList
+        )
+        self.tree.create_node(
+            identifier=CSIPAusResource.ConsumptionTariffIntervalList, parent=CSIPAusResource.TimeTariffInterval
+        )
+        self.tree.create_node(
+            identifier=CSIPAusResource.ConsumptionTariffInterval, parent=CSIPAusResource.ConsumptionTariffIntervalList
+        )
 
     def discover_resource_plan(self, target_resources: list[CSIPAusResource]) -> list[CSIPAusResource]:
         """Given a list of resource targets - calculate the ordered sequence of requests required
@@ -392,6 +434,7 @@ def generate_resource_link_hrefs(type: CSIPAusResource, resource: Resource) -> d
             return resource_link_hrefs_from_links(
                 [
                     (CSIPAusResource.DERProgramList, fsa.DERProgramListLink),
+                    (CSIPAusResource.TariffProfileList, fsa.TariffProfileListLink),
                 ]
             )
         case CSIPAusResource.DERProgram:
@@ -409,6 +452,32 @@ def generate_resource_link_hrefs(type: CSIPAusResource, resource: Resource) -> d
                     (CSIPAusResource.DERCapability, der.DERCapabilityLink),
                     (CSIPAusResource.DERSettings, der.DERSettingsLink),
                     (CSIPAusResource.DERStatus, der.DERStatusLink),
+                ]
+            )
+        case CSIPAusResource.TariffProfile:
+            tp = cast(TariffProfileResponse, resource)
+            # CombinedTimeTariffIntervalListLink uses ns="csipaus" so it's outside pydantic model_fields
+            return resource_link_hrefs_from_links(
+                [
+                    (CSIPAusResource.RateComponentList, tp.RateComponentListLink),
+                    (
+                        CSIPAusResource.CombinedTimeTariffIntervalList,
+                        getattr(tp, "CombinedTimeTariffIntervalListLink", None),
+                    ),
+                ]
+            )
+        case CSIPAusResource.RateComponent:
+            rc = cast(RateComponentResponse, resource)
+            return resource_link_hrefs_from_links(
+                [
+                    (CSIPAusResource.TimeTariffIntervalList, rc.TimeTariffIntervalListLink),
+                ]
+            )
+        case CSIPAusResource.TimeTariffInterval:
+            tti = cast(TimeTariffIntervalResponse, resource)
+            return resource_link_hrefs_from_links(
+                [
+                    (CSIPAusResource.ConsumptionTariffIntervalList, tti.ConsumptionTariffIntervalListLink),
                 ]
             )
         case _:

--- a/tests/unit/cactus_client/model/test_resource.py
+++ b/tests/unit/cactus_client/model/test_resource.py
@@ -18,6 +18,11 @@ from envoy_schema.server.schema.sep2.function_set_assignments import (
     FunctionSetAssignmentsResponse,
 )
 from envoy_schema.server.schema.sep2.identification import Resource
+from envoy_schema.server.schema.sep2.pricing import (
+    RateComponentResponse,
+    TariffProfileResponse,
+    TimeTariffIntervalResponse,
+)
 from envoy_schema.server.schema.sep2.metering_mirror import (
     MirrorUsagePointListResponse,
 )
@@ -522,6 +527,9 @@ SEP2_TYPES_WITH_LINKS: list[tuple[CSIPAusResource, type]] = [
     (CSIPAusResource.DER, DER),
     (CSIPAusResource.FunctionSetAssignments, FunctionSetAssignmentsResponse),
     (CSIPAusResource.DERProgram, DERProgramResponse),
+    (CSIPAusResource.TariffProfile, TariffProfileResponse),
+    (CSIPAusResource.RateComponent, RateComponentResponse),
+    (CSIPAusResource.TimeTariffInterval, TimeTariffIntervalResponse),
 ]
 
 


### PR DESCRIPTION
NOTE: Has a pair with PR in cactus-test-definitions (should update test defs version before release).
NOTE2: Adds some v1.3 parts to allow us to keep a single test defs and still pass all the tests. I havent added proper tests, these additions are considered placeholders not functional additions. 

Allow server setup to specify two valid NMIs for use in tests which require NMI validation to pass.
Will allow server vendors to properly enable whatever validation they need without exposing that to us. 

Allows us to do proper NMI validation but still pass S-OPT-03 with envoy.
