### PR TITLE
Improved/Fixed Aggregator EndDevice matching

### DIFF
--- a/src/cactus_client/check/end_device.py
+++ b/src/cactus_client/check/end_device.py
@@ -8,9 +8,11 @@ from envoy_schema.server.schema.sep2.end_device import (
     RegistrationResponse,
 )
 
+from cactus_client.model.config import ClientConfig
 from cactus_client.model.context import AnnotationNamespace, ExecutionContext
 from cactus_client.model.execution import CheckResult, StepExecution
 from cactus_client.model.resource import ResourceStore, StoredResource
+from cactus_client.sep2 import lfdi_from_cert_file
 
 
 def is_checksum_valid(pin: int) -> bool:
@@ -19,15 +21,8 @@ def is_checksum_valid(pin: int) -> bool:
     return pin % 10 == sum(int(d) for d in str(pin // 10)) % 10
 
 
-def match_end_device_on_lfdi_caseless(
-    resource_store: ResourceStore, lfdi: str, is_aggregator: bool = False
-) -> StoredResource | None:
-    """Does a very lightweight match on EndDevice.lfdi - returning the first EndDevice that matches or None.
-
-    If is_aggregator is True, any EndDevice whose lFDI matches the search lfdi is excluded from matching.
-    Aggregator clients always see a virtual end device with the aggregator's LFDI regardless of whether a
-    real device has been registered; other registered devices belong to different DERs and have distinct LFDIs.
-    """
+def match_end_device_on_lfdi_caseless(resource_store: ResourceStore, lfdi: str) -> StoredResource | None:
+    """Does a very lightweight match on EndDevice.lfdi - returning the first EndDevice that matches or None."""
     end_devices = resource_store.get_for_type(CSIPAusResource.EndDevice)
     if not end_devices:
         return None
@@ -39,13 +34,20 @@ def match_end_device_on_lfdi_caseless(
         if edev_resource.lFDI is None or edev_resource.lFDI.casefold() != lfdi_folded:
             continue
 
-        # At this stage the lfdi already matches, so if is aggregator, this must be the virtual edev
-        if is_aggregator:
-            continue
-
         return edev
 
     return None
+
+
+def match_aggregator_end_device(resource_store: ResourceStore, client_config: ClientConfig) -> StoredResource | None:
+    """Searches the resource_store for the CSIP Aggregator EndDevice for the specified client_config, returning it (or
+    returning None if it DNE)"""
+
+    if client_config.type != ClientType.AGGREGATOR:
+        return None
+
+    lfdi = lfdi_from_cert_file(client_config.certificate_file)
+    return match_end_device_on_lfdi_caseless(resource_store, lfdi)
 
 
 def check_end_device(
@@ -60,11 +62,7 @@ def check_end_device(
     client_config = context.client_config(step)
 
     # Start by finding a loose candidate match - then we can drill into the specifics
-    matched_edev = match_end_device_on_lfdi_caseless(
-        resource_store,
-        client_config.lfdi,
-        is_aggregator=client_config.type == ClientType.AGGREGATOR,
-    )
+    matched_edev = match_end_device_on_lfdi_caseless(resource_store, client_config.lfdi)
     if matched_edev is None:
         if matches is True:
             return CheckResult(

--- a/src/cactus_client/check/function_set_assignment.py
+++ b/src/cactus_client/check/function_set_assignment.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from cactus_test_definitions.csipaus import CSIPAusResource
-from cactus_test_definitions.server.test_procedures import ClientType
 
 from cactus_client.check.end_device import match_end_device_on_lfdi_caseless
 from cactus_client.model.context import AnnotationNamespace, ExecutionContext
@@ -25,7 +24,6 @@ def check_function_set_assignment(
         matched_edev = match_end_device_on_lfdi_caseless(
             store,
             client_config.lfdi,
-            is_aggregator=client_config.type == ClientType.AGGREGATOR,
         )
         if matched_edev is None:
             return CheckResult(

--- a/src/cactus_client/check/sep2.py
+++ b/src/cactus_client/check/sep2.py
@@ -120,7 +120,24 @@ def is_invalid_der_control(derc: DERControlResponse) -> str | None:
     )
 
 
-def is_invalid_resource(sr: StoredResource, expected_server_pen: int) -> str | None:
+def is_invalid_subscription_list(sub_list: StoredResource, aggregator_edev: StoredResource | None) -> str | None:
+    if aggregator_edev is None:
+        # All subscriptions should be discovered ONLY via the Aggregator EndDevice (eg /edev/0)
+        return (
+            f"Found SubscriptionList '{sub_list.resource.href}'"
+            + " but it doesn't appear to be nested under the (missing) aggregator EndDevice"
+        )
+
+    if not sub_list.id.is_descendent_of(aggregator_edev.id):
+        return (
+            f"Found SubscriptionList '{sub_list.resource.href}'"
+            + f" but it doesn't appear to be nested under aggregator EndDevice {aggregator_edev.resource.href}"
+        )
+
+
+def is_invalid_resource(
+    sr: StoredResource, expected_server_pen: int, aggregator_edev: StoredResource | None
+) -> str | None:
     """Does a deep inspection on sr (specifically the underlying CSIP-Aus Resource) looking for "common" failures
     of various forms. eg- having a malformed mrid
 
@@ -140,6 +157,10 @@ def is_invalid_resource(sr: StoredResource, expected_server_pen: int) -> str | N
     # DERControls
     if sr.resource_type == CSIPAusResource.DERControl:
         return is_invalid_der_control(cast(DERControlResponse, sr.resource))
+
+    # SubscriptionList
+    if sr.resource_type == CSIPAusResource.SubscriptionList:
+        return is_invalid_subscription_list(sr, aggregator_edev)
 
     # Everything is OK
     return None

--- a/src/cactus_client/cli/client.py
+++ b/src/cactus_client/cli/client.py
@@ -274,6 +274,18 @@ def prompt_new_client(console: Console, new_client_id: str) -> ClientConfig:
         lfdi = Prompt.ask("Client LFDI", console=console)
         sfdi = IntPrompt.ask("Client SFDI", console=console)
 
+    # This is likely a user misunderstanding the purpose of an AGGREGATOR client's lfdi
+    # We'll prevent this from happening as it will result in all sorts of downstream headaches otherwise
+    if client_type == ClientType.AGGREGATOR and lfdi.casefold() == lfdi_from_cert_file(cert_file).casefold():
+        console.print(
+            "[red]For an [b]Aggregator[/b] client, the LFDI/SFDI should [b]NOT[/b] match the client certificate.[/red]"
+        )
+        console.print("[red]This is to prevent a collision with the CSIP Aggregator EndDevice.[/red]")
+        console.print("[red]Use a unique LFDI/SFDI value.[/red]")
+        console.print("")
+        console.print("No changes made.")
+        sys.exit(0)
+
     client = update_client_value(console, client, ClientConfigKey.LFDI, lfdi)
     client = update_client_value(console, client, ClientConfigKey.SFDI, str(sfdi))
 

--- a/src/cactus_client/execution/execute.py
+++ b/src/cactus_client/execution/execute.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 from cactus_client.action import execute_action
 from cactus_client.admin import get_plugin_manager
 from cactus_client.check import execute_checks
+from cactus_client.check.end_device import match_aggregator_end_device
 from cactus_client.check.sep2 import is_invalid_resource
 from cactus_client.model.context import ExecutionContext
 from cactus_client.model.execution import ActionResult, ExecutionResult, StepExecution
@@ -21,8 +22,9 @@ def validate_all_resources(context: ExecutionContext) -> None:
     warnings"""
     server_pen = context.server_config.pen
     for client_context in context.clients_by_alias.values():
+        aggregator_edev = match_aggregator_end_device(client_context.discovered_resources, client_context.client_config)
         for sr in client_context.discovered_resources.resources():
-            error = is_invalid_resource(sr, server_pen)
+            error = is_invalid_resource(sr, server_pen, aggregator_edev)
             if error:
                 context.warnings.log_stored_resource_warning(sr, error)
 

--- a/tests/unit/cactus_client/check/test_end_device.py
+++ b/tests/unit/cactus_client/check/test_end_device.py
@@ -1,5 +1,6 @@
 import unittest.mock as mock
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any
 
 import pytest
@@ -17,10 +18,13 @@ from cactus_client.check.end_device import (
     check_end_device,
     check_end_device_list,
     is_checksum_valid,
+    match_aggregator_end_device,
+    match_end_device_on_lfdi_caseless,
 )
 from cactus_client.model.config import ClientConfig
 from cactus_client.model.context import AnnotationNamespace, ExecutionContext
 from cactus_client.model.execution import CheckResult, StepExecution
+from cactus_client.model.resource import StoredResource
 
 
 @pytest.mark.parametrize(
@@ -39,6 +43,110 @@ from cactus_client.model.execution import CheckResult, StepExecution
 )
 def test_is_checksum_valid(pin: int, expected: bool):
     assert is_checksum_valid(pin) == expected
+
+
+@pytest.mark.parametrize(
+    "existing_edev_lfdis, lfdi, expected_idx",
+    [
+        ([], "", None),
+        ([], "abc123", None),
+        (["abc123"], "abc123", 0),
+        (["abc123", "", "123ABC", "DEF456abc"], "DEF", None),
+        (["abc123", "", "123ABC", "DEF456abc"], "123abc", 2),
+        (["abc123", "", "123ABC", "DEF456abc"], "123ABC", 2),
+        (["abc123", "", "123ABC", "DEF456abc"], "def456ABC", 3),
+    ],
+)
+def test_match_end_device_on_lfdi_caseless(
+    testing_contexts_factory: Callable[[ClientSession], tuple[ExecutionContext, StepExecution]],
+    existing_edev_lfdis: list[str],
+    lfdi: str,
+    expected_idx: int | None,
+):
+
+    # Arrange
+    if expected_idx is not None:
+        assert expected_idx >= 0 and expected_idx < len(existing_edev_lfdis)
+
+    context, step = testing_contexts_factory(mock.Mock())
+    store = context.discovered_resources(step)
+    expected_sr: StoredResource | None = None
+    for idx, existing_lfdi in enumerate(existing_edev_lfdis):
+        new_sr = store.append_resource(
+            CSIPAusResource.EndDevice, None, generate_class_instance(EndDeviceResponse, seed=idx, lFDI=existing_lfdi)
+        )
+        if idx == expected_idx:
+            expected_sr = new_sr
+
+    # Act
+    actual_sr = match_end_device_on_lfdi_caseless(store, lfdi)
+
+    # Assert
+    if expected_sr is not None:
+        assert actual_sr is expected_sr
+    else:
+        assert actual_sr is None
+
+
+@pytest.mark.parametrize(
+    "existing_edev_lfdis, client_type, agg_edev_lfdi, expected_idx",
+    [
+        ([], ClientType.AGGREGATOR, "", None),
+        ([], ClientType.DEVICE, "", None),
+        ([], ClientType.AGGREGATOR, "abc123", None),
+        ([], ClientType.DEVICE, "abc123", None),
+        (["abc123"], ClientType.AGGREGATOR, "abc123", 0),
+        (["abc123"], ClientType.DEVICE, "abc123", None),  # Device clients never look for an agg EndDevice
+        (["abc123", "", "123ABC", "DEF456abc"], ClientType.AGGREGATOR, "DEF", None),
+        (["abc123", "", "123ABC", "DEF456abc"], ClientType.AGGREGATOR, "123abc", 2),
+        (["abc123", "", "123ABC", "DEF456abc"], ClientType.AGGREGATOR, "123ABC", 2),
+        (["abc123", "", "123ABC", "DEF456abc"], ClientType.AGGREGATOR, "def456ABC", 3),
+        (["abc123", "", "123ABC", "DEF456abc"], ClientType.DEVICE, "DEF456abc", None),
+    ],
+)
+@mock.patch("cactus_client.check.end_device.lfdi_from_cert_file")
+def test_match_aggregator_end_device(
+    mock_lfdi_from_cert_file: mock.MagicMock,
+    testing_contexts_factory: Callable[[ClientSession], tuple[ExecutionContext, StepExecution]],
+    existing_edev_lfdis: list[str],
+    client_type: ClientType,
+    agg_edev_lfdi: str,
+    expected_idx: int | None,
+):
+
+    # Arrange
+    if expected_idx is not None:
+        assert expected_idx >= 0 and expected_idx < len(existing_edev_lfdis)
+
+    # Rewrite the client config to have the nominated client type
+    context, step = testing_contexts_factory(mock.Mock())
+    store = context.discovered_resources(step)
+    client_config = replace(context.client_config(step), type=client_type)
+    context.clients_by_alias[step.client_alias].client_config = client_config
+
+    # Build the resource store
+    mock_lfdi_from_cert_file.return_value = agg_edev_lfdi
+    expected_sr: StoredResource | None = None
+    for idx, existing_lfdi in enumerate(existing_edev_lfdis):
+        new_sr = store.append_resource(
+            CSIPAusResource.EndDevice, None, generate_class_instance(EndDeviceResponse, seed=idx, lFDI=existing_lfdi)
+        )
+        if idx == expected_idx:
+            expected_sr = new_sr
+
+    # Act
+    actual_sr = match_aggregator_end_device(store, context.client_config(step))
+
+    # Assert
+    if expected_sr is not None:
+        assert actual_sr is expected_sr
+    else:
+        assert actual_sr is None
+
+    if client_type == ClientType.AGGREGATOR:
+        mock_lfdi_from_cert_file.assert_called_once_with(client_config.certificate_file)
+    else:
+        mock_lfdi_from_cert_file.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -234,83 +342,6 @@ def test_check_end_device(
         assert len(context.warnings.warnings) > 0
     else:
         assert len(context.warnings.warnings) == 0
-
-
-@pytest.mark.parametrize(
-    "client_type, edevs, client_lfdi, matches, expected_result",
-    [
-        # Aggregator: only edev/0 - matches_client:false should pass
-        (
-            ClientType.AGGREGATOR,
-            [generate_class_instance(EndDeviceResponse, lFDI="ABC123", href="/path/edev/0")],
-            "ABC123",
-            False,
-            True,
-        ),
-        # Aggregator: only edev/0 - matches_client:true should fail-
-        (
-            ClientType.AGGREGATOR,
-            [generate_class_instance(EndDeviceResponse, lFDI="ABC123", href="/path/edev/0")],
-            "ABC123",
-            True,
-            False,
-        ),
-        # Aggregator: virtual device at a non-standard path - matches_client:false should pass (LFDI-based,
-        # not href-based)
-        (
-            ClientType.AGGREGATOR,
-            [generate_class_instance(EndDeviceResponse, lFDI="ABC123", href="/path/edev/300")],
-            "ABC123",
-            False,
-            True,
-        ),
-        # Aggregator: virtual device at a non-standard path - matches_client:true should fail
-        (
-            ClientType.AGGREGATOR,
-            [generate_class_instance(EndDeviceResponse, lFDI="ABC123", href="/path/edev/300")],
-            "ABC123",
-            True,
-            False,
-        ),
-        # Device client: edev/0 - matches_client:false should fail
-        (
-            ClientType.DEVICE,
-            [generate_class_instance(EndDeviceResponse, lFDI="ABC123", href="/path/edev/0")],
-            "ABC123",
-            False,
-            False,
-        ),
-        # Device client: edev/0 - matches_client:true should pass
-        (
-            ClientType.DEVICE,
-            [generate_class_instance(EndDeviceResponse, lFDI="ABC123", href="/path/edev/0")],
-            "ABC123",
-            True,
-            True,
-        ),
-    ],
-)
-def test_check_end_device_aggregator_virtual_edev(
-    testing_contexts_factory: Callable[[ClientSession], tuple[ExecutionContext, StepExecution]],
-    assert_check_result: Callable[[CheckResult, bool], None],
-    client_type: ClientType,
-    edevs: list[EndDeviceResponse],
-    client_lfdi: str,
-    matches: bool,
-    expected_result: bool,
-):
-
-    context, step = testing_contexts_factory(mock.Mock())
-    context.clients_by_alias[step.client_alias].client_config = generate_class_instance(
-        ClientConfig, lfdi=client_lfdi, type=client_type
-    )
-
-    store = context.discovered_resources(step)
-    for edev in edevs:
-        store.append_resource(CSIPAusResource.EndDevice, None, edev)
-
-    result = check_end_device({"matches_client": matches}, step, context)
-    assert_check_result(result, expected_result)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cactus_client/check/test_sep2.py
+++ b/tests/unit/cactus_client/check/test_sep2.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from datetime import datetime
 
 import pytest
@@ -5,8 +6,10 @@ from assertical.fake.generator import generate_class_instance
 from cactus_test_definitions.csipaus import CSIPAusResource
 from envoy_schema.server.schema.sep2.der import DERControlBase, DERControlResponse
 from envoy_schema.server.schema.sep2.der_control_types import ActivePower, ReactivePower
+from envoy_schema.server.schema.sep2.end_device import EndDeviceResponse
 from envoy_schema.server.schema.sep2.identification import Resource
 from envoy_schema.server.schema.sep2.metering_mirror import MirrorUsagePoint
+from envoy_schema.server.schema.sep2.pub_sub import SubscriptionListResponse
 from envoy_schema.server.schema.sep2.time import TimeResponse
 
 from cactus_client.check.sep2 import (
@@ -15,6 +18,7 @@ from cactus_client.check.sep2 import (
     is_invalid_power_type,
     is_invalid_resource,
     is_invalid_signed_percent,
+    is_invalid_subscription_list,
 )
 from cactus_client.model.resource import (
     StoredResource,
@@ -144,6 +148,31 @@ def sr(type: CSIPAusResource, resource: Resource) -> StoredResource:
     return StoredResource(StoredResourceId(("/fake/1",)), datetime(2024, 11, 1), type, {}, None, resource)
 
 
+def test_is_invalid_subscription_list():
+    edev_1 = sr(CSIPAusResource.EndDevice, generate_class_instance(EndDeviceResponse, seed=1))
+    edev_1 = replace(edev_1, id=StoredResourceId(("/edev/1",)))
+    edev_2 = sr(CSIPAusResource.EndDevice, generate_class_instance(EndDeviceResponse, seed=2))
+    edev_2 = replace(edev_2, id=StoredResourceId(("/edev/2",)))
+
+    # Nest SubscriptionList 1 under EndDevice 1 and SubscriptionList 2 under EndDevice 2
+    sub_list_1 = sr(CSIPAusResource.SubscriptionList, generate_class_instance(SubscriptionListResponse, seed=3))
+    sub_list_2 = sr(CSIPAusResource.SubscriptionList, generate_class_instance(SubscriptionListResponse, seed=4))
+    sub_list_1 = replace(sub_list_1, id=StoredResourceId.from_parent(edev_1.id, "/sublist/1"))
+    sub_list_2 = replace(sub_list_2, id=StoredResourceId.from_parent(edev_2.id, "/sublist/2"))
+
+    # Check the valid combos
+    assert is_invalid_subscription_list(sub_list_1, edev_1) is None
+    assert is_invalid_subscription_list(sub_list_2, edev_2) is None
+
+    # No aggregator EndDevice
+    result = is_invalid_subscription_list(sub_list_1, None)
+    assert result and isinstance(result, str)
+
+    # invalid aggregator EndDevice
+    result = is_invalid_subscription_list(sub_list_1, edev_2)
+    assert result and isinstance(result, str)
+
+
 @pytest.mark.parametrize(
     "sr, expected_pass",
     [
@@ -224,10 +253,17 @@ def sr(type: CSIPAusResource, resource: Resource) -> StoredResource:
             ),
             True,
         ),
+        (
+            sr(
+                CSIPAusResource.SubscriptionList,
+                generate_class_instance(SubscriptionListResponse),
+            ),
+            False,  # No Aggregator EndDevice - therefore we fail - we will test more closely in a seperate test
+        ),
     ],
 )
 def test_is_invalid_resource(sr: StoredResource, expected_pass: bool):
-    actual = is_invalid_resource(sr, VALID_SERVER_PEN)
+    actual = is_invalid_resource(sr, VALID_SERVER_PEN, None)
     if expected_pass:
         assert actual is None
     else:


### PR DESCRIPTION
* Fixed `end-device.matches_client` not properly matching on aggregator clients
* Fixed CLI being able to create an aggregator client with lfdi/sfdi matching the expected aggregator EndDevice
* Added checks to SubscriptionList to ensure they are discovered underneath the aggregator EndDevice