### PR TITLE
Add mandatory IEEE 2030.5 cipher suite ECDHE-ECDSA-AES128-CCM8

### DIFF
--- a/src/cactus_client/execution/build.py
+++ b/src/cactus_client/execution/build.py
@@ -85,6 +85,7 @@ def build_clients_by_alias(
 
         # Load the client certs into a SSLContext
         ssl_context = SSLContext(ssl.PROTOCOL_TLSv1_2)  # TLS 1.2 required by 2030.5
+        ssl_context.set_ciphers("ECDHE-ECDSA-AES128-CCM8:DEFAULT") # ECDHE-ECDSA-AES128-CCM8 required by 2030.5
         ssl_context.check_hostname = verify_host_name
         ssl_context.verify_mode = ssl.CERT_REQUIRED if verify_ssl else ssl.CERT_NONE
         if verify_ssl and serca_pem_path:

--- a/tests/unit/cactus_client/execution/test_build.py
+++ b/tests/unit/cactus_client/execution/test_build.py
@@ -102,6 +102,25 @@ async def test_build_execution_context_s_all_01(
 
 
 @pytest.mark.asyncio
+async def test_build_execution_context_offers_mandatory_2030_5_cipher(
+    generate_testing_key_cert, no_deprecation_warnings
+):
+    """Test that the IEEE 2030.5 mandatory cipher suite (ECDHE-ECDSA-AES128-CCM8) is offered by the client."""
+    with TemporaryDirectory() as tempdirname:
+        key_file = Path(tempdirname) / "my.key"
+        cert_file = Path(tempdirname) / "my.cert"
+        generate_testing_key_cert(key_file, cert_file)
+
+        _, user_config, run_config = generate_valid_config(tempdirname, str(key_file), str(cert_file), None, None)
+
+        async with build_execution_context(user_config, run_config) as result:
+            client_context = result.clients_by_alias["client"]
+            ssl_context = client_context.session.connector._ssl
+            offered_ciphers = {c["name"] for c in ssl_context.get_ciphers()}
+            assert "ECDHE-ECDSA-AES128-CCM8" in offered_ciphers
+
+
+@pytest.mark.asyncio
 async def test_build_execution_context_junk_certs(generate_testing_key_cert, no_deprecation_warnings):
     with TemporaryDirectory() as tempdirname:
         key_file = Path(tempdirname) / "my.key"


### PR DESCRIPTION
Per IEEE 2030.5-2018 (and 2030.5-2023), all devices SHALL support `TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8`. This cipher is excluded from OpenSSL's DEFAULT cipher list  (via COMPLEMENTOFDEFAULT) and from Python's default ciphers, so the tool currently can't connect to a server that only offers the mandatory IEEE 2030.5 cipher.

This PR adds it via `ssl_context.set_ciphers("ECDHE-ECDSA-AES128-CCM8:DEFAULT")`. DEFAULT is kept as a fallback for testing servers offering other ciphers. A unit test verifies the cipher is present in the configured SSL context.