### PR TITLE
Zip report bundle

### DIFF
--- a/src/cactus_client/cli/report.py
+++ b/src/cactus_client/cli/report.py
@@ -7,7 +7,7 @@ from rich.console import Console
 
 from cactus_client.error import ConfigError
 from cactus_client.model.config import CONFIG_CWD, CONFIG_HOME, load_config
-from cactus_client.results.compliance import render_compliance_report
+from cactus_client.results.compliance import create_bundle, render_compliance_report
 
 COMMAND_NAME = "report"
 
@@ -29,6 +29,12 @@ def add_sub_commands(subparsers: argparse._SubParsersAction) -> None:
         nargs="+",
         metavar="ID",
         help="Only show results for these test procedure IDs.",
+    )
+    report_parser.add_argument(
+        "--bundle",
+        required=False,
+        action="store_true",
+        help="Also zip the latest run of each test into a cactus-bundle.{passed,failed}.zip in the output dir.",
     )
 
 
@@ -59,4 +65,14 @@ def run_action(args: argparse.Namespace) -> None:
             sys.exit(1)
         include = [TestProcedureId(id_str) for id_str in args.include]
 
-    render_compliance_report(console, Path(global_config.output_dir), include=include)
+    output_dir = Path(global_config.output_dir)
+    render_compliance_report(console, output_dir, include=include)
+
+    if args.bundle:
+        target_ids = include if include is not None else list(TestProcedureId)
+        zip_path, all_passed = create_bundle(output_dir, target_ids)
+        if all_passed:
+            console.print(f"\n[green]All {len(target_ids)} tests passed.[/green] Bundle: [b]{zip_path}[/b]")
+        else:
+            console.print(f"\n[red]Not all tests passed (see report above).[/red] Bundle: [b]{zip_path}[/b]")
+            sys.exit(2)

--- a/src/cactus_client/results/compliance.py
+++ b/src/cactus_client/results/compliance.py
@@ -1,4 +1,5 @@
 import re
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -77,3 +78,29 @@ def render_compliance_report(console: Console, output_dir: Path, include: list[T
             table.add_row(str(tp_id), "[red]FAIL[/red]", str(record.run_number))
 
     console.print(table)
+
+
+def create_bundle(output_dir: Path, target_ids: list[TestProcedureId]) -> tuple[Path, bool]:
+    """Zip the latest run of each target test into a single bundle in *output_dir*.
+
+    Returns (zip_path, all_passed) where all_passed is True only if every target test has a
+    latest run that PASSED. The zip is named ``cactus-bundle.passed.zip`` or
+    ``cactus-bundle.failed.zip`` accordingly — the filename is the pass/fail record."""
+    latest = scan_output_dir(output_dir)
+    all_passed = all((r := latest.get(tp_id)) is not None and r.result == "PASS" for tp_id in target_ids)
+
+    # Remove any stale bundle from a previous run so only the current result is present
+    for stale in ("cactus-bundle.passed.zip", "cactus-bundle.failed.zip"):
+        (output_dir / stale).unlink(missing_ok=True)
+
+    zip_path = output_dir / f"cactus-bundle.{'passed' if all_passed else 'failed'}.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for tp_id in target_ids:
+            record = latest.get(tp_id)
+            if record is None:
+                continue
+            for file in record.run_dir.rglob("*"):
+                if file.is_file():
+                    zf.write(file, file.relative_to(output_dir))
+
+    return zip_path, all_passed

--- a/src/cactus_client/results/compliance.py
+++ b/src/cactus_client/results/compliance.py
@@ -85,9 +85,15 @@ def create_bundle(output_dir: Path, target_ids: list[TestProcedureId]) -> tuple[
 
     Returns (zip_path, all_passed) where all_passed is True only if every target test has a
     latest run that PASSED. The zip is named ``cactus-bundle.passed.zip`` or
-    ``cactus-bundle.failed.zip`` accordingly — the filename is the pass/fail record."""
+    ``cactus-bundle.failed.zip`` accordingly — the filename is the pass/fail record. A top-level
+    ``compliance-report.html`` summarising every target test is also written into the bundle."""
     latest = scan_output_dir(output_dir)
     all_passed = all((r := latest.get(tp_id)) is not None and r.result == "PASS" for tp_id in target_ids)
+
+    # Render the same summary that `cactus report` prints, captured as standalone HTML
+    recorder = Console(record=True)
+    render_compliance_report(recorder, output_dir, include=target_ids)
+    summary_html = recorder.export_html()
 
     # Remove any stale bundle from a previous run so only the current result is present
     for stale in ("cactus-bundle.passed.zip", "cactus-bundle.failed.zip"):
@@ -102,5 +108,6 @@ def create_bundle(output_dir: Path, target_ids: list[TestProcedureId]) -> tuple[
             for file in record.run_dir.rglob("*"):
                 if file.is_file():
                     zf.write(file, file.relative_to(output_dir))
+        zf.writestr("compliance-report.html", summary_html)
 
     return zip_path, all_passed

--- a/tests/unit/cactus_client/results/test_compliance.py
+++ b/tests/unit/cactus_client/results/test_compliance.py
@@ -1,0 +1,78 @@
+import zipfile
+from pathlib import Path
+
+from cactus_test_definitions.server.test_procedures import TestProcedureId
+
+from cactus_client.model.output import RunOutputFile
+from cactus_client.results.compliance import create_bundle
+
+
+def make_run(output_dir: Path, run_number: int, test_id: TestProcedureId, result: str) -> Path:
+    """Create a fake run directory matching what RunOutputManager produces."""
+    run_dir = output_dir / f"run {run_number:03} - {test_id}"
+    run_dir.mkdir()
+    (run_dir / RunOutputFile.TestProcedureId).write_text(str(test_id))
+    (run_dir / RunOutputFile.Result).write_text(result)
+    (run_dir / RunOutputFile.ConsoleLogs).write_text("log line\n")
+    return run_dir
+
+
+def test_create_bundle_all_passed(tmp_path: Path):
+    make_run(tmp_path, 1, TestProcedureId.S_ALL_01, "PASS")
+    make_run(tmp_path, 2, TestProcedureId.S_ALL_02, "PASS")
+    targets = [TestProcedureId.S_ALL_01, TestProcedureId.S_ALL_02]
+
+    zip_path, all_passed = create_bundle(tmp_path, targets)
+
+    assert all_passed is True
+    assert zip_path == tmp_path / "cactus-bundle.passed.zip"
+    assert zip_path.exists()
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+    # Every target's run dir contents are bundled
+    assert "run 001 - S-ALL-01/cactus.log" in names
+    assert "run 002 - S-ALL-02/cactus.log" in names
+
+
+def test_create_bundle_failed_on_not_run(tmp_path: Path):
+    make_run(tmp_path, 1, TestProcedureId.S_ALL_01, "PASS")
+    targets = [TestProcedureId.S_ALL_01, TestProcedureId.S_ALL_02]  # S_ALL_02 never run
+
+    zip_path, all_passed = create_bundle(tmp_path, targets)
+
+    assert all_passed is False
+    assert zip_path == tmp_path / "cactus-bundle.failed.zip"
+    assert zip_path.exists()
+
+
+def test_create_bundle_failed_on_fail_result(tmp_path: Path):
+    make_run(tmp_path, 1, TestProcedureId.S_ALL_01, "FAIL")
+
+    _, all_passed = create_bundle(tmp_path, [TestProcedureId.S_ALL_01])
+
+    assert all_passed is False
+
+
+def test_create_bundle_uses_latest_run(tmp_path: Path):
+    make_run(tmp_path, 1, TestProcedureId.S_ALL_01, "FAIL")
+    make_run(tmp_path, 5, TestProcedureId.S_ALL_01, "PASS")  # latest passes
+
+    zip_path, all_passed = create_bundle(tmp_path, [TestProcedureId.S_ALL_01])
+
+    assert all_passed is True
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+    assert "run 005 - S-ALL-01/cactus.log" in names
+    assert "run 001 - S-ALL-01/cactus.log" not in names
+
+
+def test_create_bundle_removes_stale_bundle(tmp_path: Path):
+    stale = tmp_path / "cactus-bundle.failed.zip"
+    stale.write_text("old")
+    make_run(tmp_path, 1, TestProcedureId.S_ALL_01, "PASS")
+
+    create_bundle(tmp_path, [TestProcedureId.S_ALL_01])
+
+    assert not stale.exists()
+    assert (tmp_path / "cactus-bundle.passed.zip").exists()

--- a/tests/unit/cactus_client/results/test_compliance.py
+++ b/tests/unit/cactus_client/results/test_compliance.py
@@ -30,9 +30,13 @@ def test_create_bundle_all_passed(tmp_path: Path):
 
     with zipfile.ZipFile(zip_path) as zf:
         names = zf.namelist()
+        summary = zf.read("compliance-report.html").decode()
     # Every target's run dir contents are bundled
     assert "run 001 - S-ALL-01/cactus.log" in names
     assert "run 002 - S-ALL-02/cactus.log" in names
+    # A top-level HTML summary of the targets is included
+    assert "compliance-report.html" in names
+    assert "S-ALL-01" in summary and "PASS" in summary
 
 
 def test_create_bundle_failed_on_not_run(tmp_path: Path):


### PR DESCRIPTION
cactus report --bundle creates a zip file of the most recent run logs for each test. Names the file passed if every test was run and passed, else is called failed, still contains the logs.